### PR TITLE
Fixes "could not be converted to string" on normal use case.

### DIFF
--- a/src/Delivery/DynamicEntry.php
+++ b/src/Delivery/DynamicEntry.php
@@ -91,7 +91,7 @@ class DynamicEntry extends LocalizedResource implements EntryInterface
                 $locale = $this->getSpace()->getDefaultLocale();
             }
 
-            $result = $value->$locale;
+            $result = $value->{$locale->getCode()};
             if ($getId && $fieldConfig->getType() === 'Link') {
                 return $result->getId();
             }


### PR DESCRIPTION
The magic getter was trying to get the content under $field->{en-US} using an object instead of the locale code. 

Had to patch this to get a simple blog post to display it's title properly.   