### PR TITLE
fixed an issue if a DynamicEntry has a oneToMany link but has hanging…

### DIFF
--- a/src/Delivery/Client.php
+++ b/src/Delivery/Client.php
@@ -10,6 +10,7 @@ use Contentful\Client as BaseClient;
 use Contentful\Delivery\Synchronization\Manager;
 use Contentful\Query as BaseQuery;
 use Contentful\Log\LoggerInterface;
+use Contentful\ResourceNotFoundException;
 
 /**
  * A Client is used to communicate the Contentful Delivery API.
@@ -203,16 +204,19 @@ class Client extends BaseClient
      */
     public function resolveLink(Link $link)
     {
-        $id = $link->getId();
-        $type = $link->getLinkType();
+        try {
+            $id = $link->getId();
+            $type = $link->getLinkType();
 
-        switch ($link->getLinkType()) {
-            case 'Entry':
-                return $this->getEntry($id);
-            case 'Asset':
-                return $this->getAsset($id);
-            default:
-                throw new \InvalidArgumentException('Tyring to resolve link for unknown type "' . $type . '".');
+            switch ($link->getLinkType()) {
+                case 'Entry':
+                    return $this->getEntry($id);
+                case 'Asset':
+                    return $this->getAsset($id);
+                default:
+                    throw new \InvalidArgumentException('Tyring to resolve link for unknown type "' . $type . '".');
+        } catch (ResourceNotFoundException $e) {
+            return [];
         }
     }
 


### PR DESCRIPTION
We added this to fix an issue we are facing when an entry has a child link that is deleted:

Steps to replicate: 

1. Create entry with oneToMany reference.
2. Create two entries and assign to that reference.
3. Delete one of two entries.
4. Try and retrieve that field $entry->getOneToMany(), it will fail because there is a hanging reference of a previously deleted entry, making it impossible to retrieve the one does exist.