### PR TITLE
[client] : Allow httpClient to be overridden

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -66,6 +66,13 @@ abstract class Client
         ]);
     }
 
+    /**
+     * Override the default httpClient
+     *
+     * @param GuzzleClient $httpClient
+     *
+     * @return self
+     */
     public function setHttpClient(GuzzleClient $httpClient)
     {
         // Ensure that the BearerToken middleware is added to the custom client

--- a/src/Client.php
+++ b/src/Client.php
@@ -27,6 +27,11 @@ abstract class Client
     /**
      * @var string
      */
+    private $token;
+
+    /**
+     * @var string
+     */
     private $baseUri;
 
     /**
@@ -51,6 +56,7 @@ abstract class Client
     {
         $stack = HandlerStack::create();
         $stack->push(new BearerToken($token));
+        $this->token = $token;
         $this->logger = $logger ?: new NullLogger();
 
         $this->api = $api;
@@ -58,6 +64,16 @@ abstract class Client
         $this->httpClient = new GuzzleClient([
             'handler' => $stack
         ]);
+    }
+
+    public function setHttpClient(GuzzleClient $httpClient)
+    {
+        // Ensure that the BearerToken middleware is added to the custom client
+        $httpClient->getConfig('handler')->push(new BearerToken($this->token));
+
+        $this->httpClient = $httpClient;
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
In order to enable the user to add custom middleware to the GuzzleHttp\Client object, the private class variable `httpClient` needs to be accessible for overriding.

By storing the constructor param, `$token`, in the class variable `self::$token` we can easily ensure that the `BearerToken()` middleware is pushed to the handler stack when a custom httpClient is provided.

For my use-case, I wanted to add custom GuzzleHttp middleware to cache the API results to cut-down on API calls and speed up the site.  A somewhat better option might be to do some sort of full-page caching with a reverse-proxy but that gets complicated when you have users logged into your application.

@realityking I am pinging you as you seem to be the main/only author of the Contentful\Client class.
