### PR TITLE
Removes the caching of Entry and Asset instances.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 * Changed the behavior of getting an array of links to not throw an exception when one of them has been deleted from the space. ([#19](https://github.com/contentful/contentful.php/pull/19))
 * Drop `BearerToken` to make it easier to inject custom Guzzle instances. **[BREAKING]**
+* Removed the caching of `Asset` and `Entry` instances. **[BREAKING]**
 
 ### Fixed
 * Assets that have no title would throw an uncaught exception.

--- a/src/Delivery/Client.php
+++ b/src/Delivery/Client.php
@@ -84,10 +84,6 @@ class Client extends BaseClient
      */
     public function getAsset($id)
     {
-        if ($this->instanceCache->hasAsset($id)) {
-            return $this->instanceCache->getAsset($id);
-        }
-
         return $this->requestAndBuild('GET', 'assets/' . $id, [
             'query' => ['locale' => '*']
         ]);
@@ -151,10 +147,6 @@ class Client extends BaseClient
      */
     public function getEntry($id)
     {
-        if ($this->instanceCache->hasEntry($id)) {
-            return $this->instanceCache->getEntry($id);
-        }
-
         return $this->requestAndBuild('GET', 'entries/' . $id, [
             'query' => ['locale' => '*']
         ]);

--- a/src/Delivery/DynamicEntry.php
+++ b/src/Delivery/DynamicEntry.php
@@ -16,6 +16,11 @@ class DynamicEntry extends LocalizedResource implements EntryInterface
     private $fields;
 
     /**
+     * @var array
+     */
+    private $resolvedLinks = [];
+
+    /**
      * @var SystemProperties
      */
     protected $sys;
@@ -39,6 +44,7 @@ class DynamicEntry extends LocalizedResource implements EntryInterface
         $this->fields = $fields;
         $this->sys = $sys;
         $this->client = $client;
+        $this->resolvedLinks = [];
     }
 
     public function getId()
@@ -130,7 +136,15 @@ class DynamicEntry extends LocalizedResource implements EntryInterface
         }
 
         if ($result instanceof Link) {
-            return $client->resolveLink($result);
+            $cacheId = $result->getLinkType() . '-' . $result->getId();
+            if (isset($this->resolvedLinks[$cacheId])) {
+                return $this->resolvedLinks[$cacheId];
+            }
+
+            $resolvedObj = $client->resolveLink($result);
+            $this->resolvedLinks[$cacheId] = $resolvedObj;
+
+            return $resolvedObj;
         }
 
         if ($fieldConfig->getType() === 'Array' && $fieldConfig->getItemsType() === 'Link') {

--- a/src/Delivery/InstanceCache.php
+++ b/src/Delivery/InstanceCache.php
@@ -14,19 +14,9 @@ class InstanceCache
     private $space;
 
     /**
-     * @var Asset[]
-     */
-    private $assets = [];
-
-    /**
      * @var ContentType[]
      */
     private $contentTypes = [];
-
-    /**
-     * @var DynamicEntry[]
-     */
-    private $entries = [];
 
     /**
      * InstanceCache constructor.
@@ -68,40 +58,6 @@ class InstanceCache
     }
 
     /**
-     * Get the asset with the specified ID out of the cache
-     *
-     * @param  string $id
-     *
-     * @return Asset|null
-     */
-    public function getAsset($id)
-    {
-        if (!isset($this->assets[$id])) {
-            return null;
-        }
-
-        return $this->assets[$id];
-    }
-
-    /**
-     * @param  string $id
-     *
-     * @return bool
-     */
-    public function hasAsset($id)
-    {
-        return isset($this->assets[$id]);
-    }
-
-    /**
-     * @param Asset $asset
-     */
-    public function addAsset(Asset $asset)
-    {
-        $this->assets[$asset->getId()] = $asset;
-    }
-
-    /**
      * @param  string $id
      *
      * @return ContentType|null
@@ -131,37 +87,5 @@ class InstanceCache
     public function addContentType(ContentType $contentType)
     {
         $this->contentTypes[$contentType->getId()] = $contentType;
-    }
-
-    /**
-     * @param  string $id
-     *
-     * @return DynamicEntry|null
-     */
-    public function getEntry($id)
-    {
-        if (!isset($this->entries[$id])) {
-            return null;
-        }
-
-        return $this->entries[$id];
-    }
-
-    /**
-     * @param  string $id
-     *
-     * @return bool
-     */
-    public function hasEntry($id)
-    {
-        return isset($this->entries[$id]);
-    }
-
-    /**
-     * @param DynamicEntry $entry
-     */
-    public function addEntry(DynamicEntry $entry)
-    {
-        $this->entries[$entry->getId()] = $entry;
     }
 }

--- a/tests/E2E/EntryBasicTest.php
+++ b/tests/E2E/EntryBasicTest.php
@@ -60,4 +60,22 @@ class EntryBasicTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(Asset::class, $image);
         $this->assertEquals('nyancat', $image->getId());
     }
+
+    /**
+     * @vcr e2e_entry_lazy_loading_cached.json
+     */
+    public function testLazyLoadIsCached()
+    {
+        $nyancat = $this->client->getEntry('nyancat');
+        $bestFriend = $nyancat->getBestFriend();
+
+        // Locally it's cached
+        $this->assertEquals('happycat', $bestFriend->getId());
+        $this->assertSame($bestFriend, $nyancat->getBestFriend());
+
+        // but not globally
+        $happycat = $this->client->getEntry('happycat');
+        $this->assertEquals($bestFriend->getId(), $happycat->getId());
+        $this->assertNotSame($bestFriend, $happycat);
+    }
 }


### PR DESCRIPTION
The instance cache represents a form of global state. Since Entry and Asset allow
switching between locales this state has caused some confusion.

It's also incompatible with future changes that are planned, including support for the
`select` and locale `operators`.