### PR TITLE
Fixes the inability to access fields where the first letter of the ID is capitalized.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Fields that have the literal value `null` are now treated like they don't exist. Previously they might have causes a
 fatal error. **Note:** This does not 100% match the behaviour of the Contentful API.
 * The error message for `Query::setLimit` was incorrect.
+* Allow accessing fields where the first letter of the ID is capitalized. ([#68](https://github.com/contentful/contentful.php/pull/68))
 
 ## [0.6.5-beta](https://github.com/contentful/contentful.php/tree/0.6.5-beta) (2016-09-10)
 

--- a/tests/Unit/Delivery/DynamicEntryTest.php
+++ b/tests/Unit/Delivery/DynamicEntryTest.php
@@ -65,6 +65,7 @@ class DynamicEntryTest extends \PHPUnit_Framework_TestCase
                 new ContentTypeField('likes', 'Likes', 'Array', null, 'Symbol', false, false),
                 new ContentTypeField('color', 'Color', 'Symbol', null, null, false, false),
                 new ContentTypeField('bestFriend', 'Best Friend', 'Link', 'Entry', null, false, false),
+                new ContentTypeField('Enemy', 'Enemy', 'Link', 'Entry', null, false, false),
                 new ContentTypeField('birthday', 'Birthday', 'Date', null, null, false, false),
                 new ContentTypeField('lifes', 'Lifes left', 'Integer', null, null, false, false, true),
                 new ContentTypeField('lives', 'Lives left', 'Integer', null, null, false, false),
@@ -86,6 +87,12 @@ class DynamicEntryTest extends \PHPUnit_Framework_TestCase
         $mockEntry->method('getId')
             ->willReturn('happycat');
 
+        $mockEntryEnemy = $this->getMockBuilder(DynamicEntry::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mockEntryEnemy->method('getId')
+            ->willReturn('garfield');
+
         $mockAsset = $this->getMockBuilder(Asset::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -106,6 +113,9 @@ class DynamicEntryTest extends \PHPUnit_Framework_TestCase
                 ],
                 'bestFriend' => [
                     'en-US' => $mockEntry
+                ],
+                'Enemy' => [
+                    'en-US' => $mockEntryEnemy
                 ],
                 'birthday' => [
                     'en-US' => new \DateTimeImmutable('2011-04-04T22:00:00+00:00')
@@ -133,6 +143,7 @@ class DynamicEntryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($this->space, $entry->getSpace());
         $this->assertEquals($this->ct, $entry->getContentType());
         $this->assertEquals('happycat', $entry->getBestFriend()->getId());
+        $this->assertEquals('garfield', $entry->getEnemy()->getId());
     }
 
     public function testIdGetter()
@@ -140,6 +151,7 @@ class DynamicEntryTest extends \PHPUnit_Framework_TestCase
         $entry = $this->entry;
 
         $this->assertEquals('happycat', $entry->getBestFriendId());
+        $this->assertEquals('garfield', $entry->getEnemyId());
     }
 
     public function testLinkResolution()
@@ -386,6 +398,6 @@ class DynamicEntryTest extends \PHPUnit_Framework_TestCase
 
     public function testJsonSerialize()
     {
-        $this->assertJsonStringEqualsJsonString('{"fields":{"name":{"en-US":"Nyan Cat","tlh":"Nyan vIghro\'"},"likes":{"en-US":["rainbows","fish"]},"color":{"en-US":"rainbow"},"bestFriend":{"en-US":{"sys":{"type":"Link","linkType":"Entry","id":"happycat"}}},"birthday":{"en-US":"2011-04-04T22:00:00.000Z"},"lives":{"en-US":1337},"image":{"en-US":{"sys":{"type":"Link","linkType":"Asset","id":"nyancat"}}}},"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"cfexampleapi"}},"type":"Entry","contentType":{"sys":{"type":"Link","linkType":"ContentType","id":"cat"}},"id":"nyancat","revision":5,"createdAt":"2013-06-27T22:46:19.513Z","updatedAt":"2013-09-04T09:19:39.027Z"}}', json_encode($this->entry));
+        $this->assertJsonStringEqualsJsonString('{"fields":{"name":{"en-US":"Nyan Cat","tlh":"Nyan vIghro\'"},"likes":{"en-US":["rainbows","fish"]},"color":{"en-US":"rainbow"},"bestFriend":{"en-US":{"sys":{"type":"Link","linkType":"Entry","id":"happycat"}}},"Enemy":{"en-US":{"sys":{"type":"Link","linkType":"Entry","id":"garfield"}}},"birthday":{"en-US":"2011-04-04T22:00:00.000Z"},"lives":{"en-US":1337},"image":{"en-US":{"sys":{"type":"Link","linkType":"Asset","id":"nyancat"}}}},"sys":{"space":{"sys":{"type":"Link","linkType":"Space","id":"cfexampleapi"}},"type":"Entry","contentType":{"sys":{"type":"Link","linkType":"ContentType","id":"cat"}},"id":"nyancat","revision":5,"createdAt":"2013-06-27T22:46:19.513Z","updatedAt":"2013-09-04T09:19:39.027Z"}}', json_encode($this->entry));
     }
 }


### PR DESCRIPTION
Fixes #68

Note: This does not support having the same field name with different capitalization on the first letter.