### PR TITLE
Removes HHVM from the test matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,8 @@ php:
   - 5.5
   - 5.6
   - 7.0
-  - hhvm
 
 matrix:
-  allow_failures:
-   - php: hhvm
   fast_finish: true
 
 branches:


### PR DESCRIPTION
The tests have never passed and interest in HHVM has faded enough that it's not worth considering it anymore.

Partly adresses #74 