### PR TITLE
Update .gitarributes to exclude the tests from generated zip files.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,12 @@
 * text=auto
 
-.travis.yml export-ignore
-.gitattributes export-ignore
-.gitignore export-ignore
-.editorconfig export-ignore
+/.travis.yml export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.editorconfig export-ignore
+/.coveralls.yml export-ignore
+/.php_cs export-ignore
+/phpdoc.dist.xml export-ignore
+/phpunit.xml.dist export-ignore
+/phpunit-api-coverage.xml export-ignore
+/tests export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Moved all Exception classes to their own namespace. **[BREAKING]**
 * Changed the signature of the constructor of `Contentful\Delivery\Client`. Several options are now in an options array. **[BREAKING]**
 * The Sync API can now also be used with the Preview API. Only initial syncs are supported.
+* Dist zip files no longer include the tests directory. If you need them use `composer install --prefer-source`.
 
 ### Removed
 * Dropped `BearerToken` to make it easier to inject custom Guzzle instances. **[BREAKING]**


### PR DESCRIPTION
This is mainly for the benefit of composer users not having to download all the stuf they don't need.