### PR TITLE
Changes File::getUrl to always return a URL prefixed with a protocol.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Changed the signature of the constructor of `Contentful\Delivery\Client`. Several options are now in an options array. **[BREAKING]**
 * The Sync API can now also be used with the Preview API. Only initial syncs are supported.
 * Dist zip files no longer include the tests directory. If you need them use `composer install --prefer-source`.
+* `File::getUrl` always returns the URL to the file prefixed with a protocol. Previously it would have been a protocol relative URL. **[BREAKING]**
 
 ### Removed
 * Dropped `BearerToken` to make it easier to inject custom Guzzle instances. **[BREAKING]**

--- a/src/Delivery/File.php
+++ b/src/Delivery/File.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright 2015 Contentful GmbH
+ * @copyright 2015-2017 Contentful GmbH
  * @license   MIT
  */
 
@@ -77,6 +77,10 @@ class File implements \JsonSerializable
      */
     public function getUrl()
     {
+        if (substr($this->url, 0, 2) === '//') {
+            return 'https:' . $this->url;
+        }
+
         return $this->url;
     }
 

--- a/tests/Unit/Delivery/FileTest.php
+++ b/tests/Unit/Delivery/FileTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright 2015 Contentful GmbH
+ * @copyright 2015-2017 Contentful GmbH
  * @license   MIT
  */
 
@@ -36,8 +36,24 @@ class FileTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals('Nyan_cat_250px_frame.png', $this->file->getFileName());
         $this->assertEquals('image/png', $this->file->getContentType());
-        $this->assertEquals('//images.contentful.com/cfexampleapi/4gp6taAwW4CmSgumq2ekUm/9da0cd1936871b8d72343e895a00d611/Nyan_cat_250px_frame.png', $this->file->getUrl());
+        $this->assertEquals('https://images.contentful.com/cfexampleapi/4gp6taAwW4CmSgumq2ekUm/9da0cd1936871b8d72343e895a00d611/Nyan_cat_250px_frame.png', $this->file->getUrl());
         $this->assertEquals(12273, $this->file->getSize());
+    }
+
+    /**
+     * @covers \Contentful\Delivery\File::__construct
+     * @covers \Contentful\Delivery\File::getUrl
+     */
+    public function testNoUlrChangeWithProtocol()
+    {
+        $file = new File(
+            'Nyan_cat_250px_frame.png',
+            'image/png',
+            'http://images.contentful.com/cfexampleapi/4gp6taAwW4CmSgumq2ekUm/9da0cd1936871b8d72343e895a00d611/Nyan_cat_250px_frame.png',
+            12273
+        );
+
+        $this->assertEquals('http://images.contentful.com/cfexampleapi/4gp6taAwW4CmSgumq2ekUm/9da0cd1936871b8d72343e895a00d611/Nyan_cat_250px_frame.png', $file->getUrl());
     }
 
     /**

--- a/tests/Unit/Delivery/ImageFileTest.php
+++ b/tests/Unit/Delivery/ImageFileTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright 2015 Contentful GmbH
+ * @copyright 2015-2017 Contentful GmbH
  * @license   MIT
  */
 
@@ -39,7 +39,7 @@ class ImageFileTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetter()
     {
-        $this->assertEquals('//images.contentful.com/cfexampleapi/4gp6taAwW4CmSgumq2ekUm/9da0cd1936871b8d72343e895a00d611/Nyan_cat_250px_frame.png', $this->file->getUrl());
+        $this->assertEquals('https://images.contentful.com/cfexampleapi/4gp6taAwW4CmSgumq2ekUm/9da0cd1936871b8d72343e895a00d611/Nyan_cat_250px_frame.png', $this->file->getUrl());
         $this->assertEquals(250, $this->file->getWidth());
         $this->assertEquals(250, $this->file->getHeight());
     }
@@ -61,7 +61,7 @@ class ImageFileTest extends \PHPUnit_Framework_TestCase
             ->willReturn('fm=jpg&q=50');
 
         $this->assertEquals(
-            '//images.contentful.com/cfexampleapi/4gp6taAwW4CmSgumq2ekUm/9da0cd1936871b8d72343e895a00d611/Nyan_cat_250px_frame.png?fm=jpg&q=50',
+            'https://images.contentful.com/cfexampleapi/4gp6taAwW4CmSgumq2ekUm/9da0cd1936871b8d72343e895a00d611/Nyan_cat_250px_frame.png?fm=jpg&q=50',
             $this->file->getUrl($stub)
         );
     }


### PR DESCRIPTION
Previously it would have been a protocol relative URL.

I'd like to make this change because outside of the (admittedly, most common) use-case of embedding the url in some HTML and showing it in a browser these URLs won't actually work. By managing the protocol in the SDK we avoid people manually prefixing them by just doing `https: . $file->getUrl()` which would break if we ever drop the protocol relative URLs.

Paul Irish agrees too https://twitter.com/paul_irish/status/588502455530311680?lang=de