### PR TITLE
Remove symfony/console from the dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,14 +6,13 @@
     "require": {
         "php": "^5.5.9|^7.0",
         "guzzlehttp/guzzle": "^6.2.1",
-        "symfony/console": "~2.7|~3.0",
         "guzzlehttp/psr7": "~1.1",
         "psr/http-message": "~1.0"
     },
     "require-dev": {
         "php-vcr/phpunit-testlistener-vcr": "^1.1",
-        "jakub-onderka/php-parallel-lint": "^0.9.2",
-        "jakub-onderka/php-console-highlighter": "^0.3.2"
+        "jakub-onderka/php-parallel-lint": "^0.9",
+        "jakub-onderka/php-console-highlighter": "^0.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Symfony console is not used within the project and this being in the dependency manifest along with the version restriction means that this is not installable via Composer with Magento 2.