### PR TITLE
Removes all get* methods from the various query classes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/contentful/ContentfulBundle/compare/0.7.0-beta...HEAD)
 
+### Removed
+* Removed all get* methods except `getQueryData()` and `getQueryString()` from the various query classes. **[BREAKING]**
+
 ## [0.7.0-beta](https://github.com/contentful/contentful.php/tree/0.7.0-beta) (2017-04-06)
 
 **ATTENTION**: This release contains breaking changes. Please take extra care when updating to this version.

--- a/src/Delivery/Query.php
+++ b/src/Delivery/Query.php
@@ -50,18 +50,6 @@ class Query extends BaseQuery
     }
 
     /**
-     * Get the amount of levels of links that should be resolved.
-     *
-     * @return int|null
-     *
-     * @api
-     */
-    public function getInclude()
-    {
-        return $this->include;
-    }
-
-    /**
      * Set the amount of levels of links that should be resolved.
      *
      * @param  int|null $include
@@ -75,18 +63,6 @@ class Query extends BaseQuery
         $this->include = $include;
 
         return $this;
-    }
-
-    /**
-     * Gets the locale for which content should be retrieved.
-     *
-     * @return string|null
-     *
-     * @api
-     */
-    public function getLocale()
-    {
-        return $this->locale;
     }
 
     /**

--- a/src/Delivery/Synchronization/Query.php
+++ b/src/Delivery/Synchronization/Query.php
@@ -72,18 +72,6 @@ class Query
     /**
      * Set the Type of event or resource to sync.
      *
-     * May be null if everything is synced.
-     *
-     * @return string
-     */
-    public function getType()
-    {
-        return $this->type;
-    }
-
-    /**
-     * Set the Type of event or resource to sync.
-     *
      * Set to null to sync everything.
      *
      * Valid values for $type are:
@@ -112,18 +100,6 @@ class Query
         $this->type = $type;
 
         return $this;
-    }
-
-    /**
-     * Returns the name of the content type for which results will be retrieved. Can be NULL if no content type is set
-     *
-     * @return string|null The name of the content type results will be limited to
-     *
-     * @api
-     */
-    public function getContentType()
-    {
-        return $this->contentType;
     }
 
     /**

--- a/src/Query.php
+++ b/src/Query.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright 2015 Contentful GmbH
+ * @copyright 2015-2017 Contentful GmbH
  * @license   MIT
  */
 
@@ -163,18 +163,6 @@ class Query
     }
 
     /**
-     * Returns the index of the first result to retrieve. Can return NULL if no index is specified.
-     *
-     * @return int|null
-     *
-     * @api
-     */
-    public function getSkip()
-    {
-        return $this->skip;
-    }
-
-    /**
      * Set the maximum number of results to retrieve. To reset set to NULL;
      *
      * @param  int|null $limit The maximum number of results to retrieve, must be between 1 and 1000 or null
@@ -194,18 +182,6 @@ class Query
         $this->limit = $limit;
 
         return $this;
-    }
-
-    /**
-     * Returns the maximum number of results to retrieve. Can return NULL if no maximum is defined.
-     *
-     * @return int|null
-     *
-     * @api
-     */
-    public function getLimit()
-    {
-        return $this->limit;
     }
 
     /**
@@ -254,18 +230,6 @@ class Query
     }
 
     /**
-     * Returns the name of the content type for which results will be retrieved. Can be NULL if no content type is set
-     *
-     * @return string|null The name of the content type results will be limited to
-     *
-     * @api
-     */
-    public function getContentType()
-    {
-        return $this->contentType;
-    }
-
-    /**
      * @param  string|null $group
      *
      * @return $this
@@ -297,14 +261,6 @@ class Query
         $this->mimeTypeGroup = $group;
 
         return $this;
-    }
-
-    /**
-     * @return null|string
-     */
-    public function getMimeTypeGroup()
-    {
-        return $this->mimeTypeGroup;
     }
 
     /**

--- a/tests/Unit/Delivery/QueryTest.php
+++ b/tests/Unit/Delivery/QueryTest.php
@@ -13,19 +13,6 @@ class QueryTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers Contentful\Delivery\Query::__construct
      * @covers Contentful\Delivery\Query::setInclude
-     * @covers Contentful\Delivery\Query::getInclude
-     */
-    public function testGetSetInclude()
-    {
-        $query = new Query;
-        $query->setInclude(50);
-
-        $this->assertEquals(50, $query->getInclude());
-    }
-
-    /**
-     * @covers Contentful\Delivery\Query::__construct
-     * @covers Contentful\Delivery\Query::setInclude
      * @covers Contentful\Delivery\Query::getQueryData
      * @covers Contentful\Query::getQueryData
      * @covers Contentful\Query::getQueryString
@@ -36,19 +23,6 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         $query->setInclude(50);
 
         $this->assertEquals('include=50', $query->getQueryString());
-    }
-
-    /**
-     * @covers Contentful\Delivery\Query::__construct
-     * @covers Contentful\Delivery\Query::setLocale
-     * @covers Contentful\Delivery\Query::getLocale
-     */
-    public function testGetSetLocale()
-    {
-        $query = new Query;
-        $query->setLocale('de-DE');
-
-        $this->assertEquals('de-DE', $query->getLocale());
     }
 
     /**

--- a/tests/Unit/Delivery/Synchronization/QueryTest.php
+++ b/tests/Unit/Delivery/Synchronization/QueryTest.php
@@ -23,18 +23,6 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('initial=1', $queryBuilder->getQueryString());
     }
 
-    /**
-     * @covers Contentful\Delivery\Synchronization\Query::__construct
-     * @covers Contentful\Delivery\Synchronization\Query::setType
-     * @covers Contentful\Delivery\Synchronization\Query::getType
-     */
-    public function testGetSetType()
-    {
-        $queryBuilder = new Query;
-        $queryBuilder->setType('Entry');
-
-        $this->assertEquals('Entry', $queryBuilder->getType());
-    }
 
     /**
      * @covers Contentful\Delivery\Synchronization\Query::__construct
@@ -67,23 +55,9 @@ class QueryTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers Contentful\Delivery\Synchronization\Query::__construct
      * @covers Contentful\Delivery\Synchronization\Query::setContentType
-     * @covers Contentful\Delivery\Synchronization\Query::getContentType
+     * @covers Contentful\Delivery\Synchronization\Query::getQueryString
      *
-     * @uses Contentful\Delivery\Synchronization\Query::setType
-     */
-    public function testGetSetContentType()
-    {
-        $queryBuilder = new Query;
-        $queryBuilder->setContentType('cat');
-
-        $this->assertEquals('cat', $queryBuilder->getContentType());
-    }
-
-    /**
-     * @covers Contentful\Delivery\Synchronization\Query::__construct
-     * @covers Contentful\Delivery\Synchronization\Query::setContentType
-     * @covers Contentful\Delivery\Synchronization\Query::getContentType
-     *
+     * @uses Contentful\Delivery\Synchronization\Query::getQueryData
      * @uses Contentful\Delivery\Synchronization\Query::setType
      */
     public function testGetSetContentTypeFromObject()
@@ -98,7 +72,7 @@ class QueryTest extends \PHPUnit_Framework_TestCase
 
         $queryBuilder->setContentType($contentType);
 
-        $this->assertEquals('cat', $queryBuilder->getContentType());
+        $this->assertEquals('initial=1&type=Entry&content_type=cat', $queryBuilder->getQueryString());
     }
 
     /**

--- a/tests/Unit/QueryTest.php
+++ b/tests/Unit/QueryTest.php
@@ -27,19 +27,6 @@ class QueryTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers Contentful\Query::__construct
      * @covers Contentful\Query::setLimit
-     * @covers Contentful\Query::getLimit
-     */
-    public function testGetSetLimit()
-    {
-        $queryBuilder = new Query;
-        $queryBuilder->setLimit(150);
-
-        $this->assertEquals(150, $queryBuilder->getLimit());
-    }
-
-    /**
-     * @covers Contentful\Query::__construct
-     * @covers Contentful\Query::setLimit
      * @covers Contentful\Query::getQueryData
      * @covers Contentful\Query::getQueryString
      */
@@ -101,19 +88,6 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         $queryBuilder->setLimit(null);
 
         $this->assertEquals('', $queryBuilder->getQueryString());
-    }
-
-    /**
-     * @covers Contentful\Query::__construct
-     * @covers Contentful\Query::setSkip
-     * @covers Contentful\Query::getSkip
-     */
-    public function testGetSetSkip()
-    {
-        $queryBuilder = new Query;
-        $queryBuilder->setSkip(10);
-
-        $this->assertEquals(10, $queryBuilder->getSkip());
     }
 
     /**
@@ -188,20 +162,9 @@ class QueryTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers Contentful\Query::__construct
      * @covers Contentful\Query::setContentType
-     * @covers Contentful\Query::getContentType
-     */
-    public function testGetSetContentType()
-    {
-        $queryBuilder = new Query;
-        $queryBuilder->setContentType('cat');
-
-        $this->assertEquals('cat', $queryBuilder->getContentType());
-    }
-
-    /**
-     * @covers Contentful\Query::__construct
-     * @covers Contentful\Query::setContentType
-     * @covers Contentful\Query::getContentType
+     * @covers Contentful\Query::getQueryString
+     *
+     * @uses Contentful\Query::getQueryData
      */
     public function testGetSetContentTypeFromObject()
     {
@@ -215,7 +178,7 @@ class QueryTest extends \PHPUnit_Framework_TestCase
 
         $queryBuilder->setContentType($contentType);
 
-        $this->assertEquals('cat', $queryBuilder->getContentType());
+        $this->assertEquals('content_type=cat', $queryBuilder->getQueryString());
     }
 
     /**
@@ -329,19 +292,6 @@ class QueryTest extends \PHPUnit_Framework_TestCase
     {
         $queryBuilder = new Query;
         $queryBuilder->where('sys.id', 'nyancat', 'wrong');
-    }
-
-    /**
-     * @covers Contentful\Query::__construct
-     * @covers Contentful\Query::setMimeTypeGroup
-     * @covers Contentful\Query::getMimeTypeGroup
-     */
-    public function testGetSetMimeTypeGroup()
-    {
-        $queryBuilder = new Query;
-        $queryBuilder->setMimeTypeGroup('image');
-
-        $this->assertEquals('image', $queryBuilder->getMimeTypeGroup());
     }
 
     /**


### PR DESCRIPTION
Except `getQueryData()` and `getQueryString()`.