### PR TITLE
Adds DeletedEntry::getContentType() to make that data accessible.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/contentful/contentful.php/compare/1.0.0...HEAD)
 
+### Added
+* Implemented `DeletedEntry::getContentType()` to be used with webhooks. ([#101](https://github.com/contentful/contentful.php/pull/101))
+
 ### Changed
 * The minimum required version of `guzzlehttp/psr7` is now 1.4.
 

--- a/src/Delivery/Synchronization/DeletedEntry.php
+++ b/src/Delivery/Synchronization/DeletedEntry.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright 2015 Contentful GmbH
+ * @copyright 2015-2017 Contentful GmbH
  * @license   MIT
  */
 
@@ -13,4 +13,13 @@ namespace Contentful\Delivery\Synchronization;
  */
 class DeletedEntry extends DeletedResource
 {
+    /**
+     * This method always returns null when used with the sync API. It does return a value when parsing a webhook response.
+     *
+     * @return \Contentful\Delivery\ContentType|null
+     */
+    public function getContentType()
+    {
+        return $this->sys->getContentType();
+    }
 }

--- a/src/Delivery/Synchronization/DeletedResource.php
+++ b/src/Delivery/Synchronization/DeletedResource.php
@@ -16,7 +16,7 @@ abstract class DeletedResource implements \JsonSerializable
     /**
      * @var SystemProperties
      */
-    private $sys;
+    protected $sys;
 
     /**
      * DeletedResource constructor.

--- a/tests/Unit/Delivery/Synchronization/DeletedResourceTest.php
+++ b/tests/Unit/Delivery/Synchronization/DeletedResourceTest.php
@@ -6,6 +6,8 @@
 
 namespace Contentful\Tests\Unit\Delivery\Synchronization;
 
+use Contentful\Delivery\ContentType;
+use Contentful\Delivery\Synchronization\DeletedEntry;
 use Contentful\Delivery\Synchronization\DeletedResource;
 use Contentful\Delivery\Space;
 use Contentful\Delivery\SystemProperties;
@@ -52,6 +54,43 @@ class DeletedResourceTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(new \DateTimeImmutable('2014-08-11T08:30:42.559Z'), $resource->getCreatedAt());
         $this->assertEquals(new \DateTimeImmutable('2014-08-12T08:30:42.559Z'), $resource->getUpdatedAt());
         $this->assertEquals(new \DateTimeImmutable('2014-08-13T08:30:42.559Z'), $resource->getDeletedAt());
+    }
+
+    public function testContentTypeDeletedEntry()
+    {
+        $space = $this->getMockBuilder(Space::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $deletedEntry = new DeletedEntry(new SystemProperties(
+            '4rPdazIwWkuuKEAQgemSmO',
+            'DeletedEntry',
+            $space,
+            null,
+            1,
+            new \DateTimeImmutable('2014-08-11T08:30:42.559Z'),
+            new \DateTimeImmutable('2014-08-12T08:30:42.559Z'),
+            new \DateTimeImmutable('2014-08-13T08:30:42.559Z')
+        ));
+
+        $this->assertNull($deletedEntry->getContentType());
+
+        $ct = $this->getMockBuilder(ContentType::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $deletedEntry = new DeletedEntry(new SystemProperties(
+            '4rPdazIwWkuuKEAQgemSmO',
+            'DeletedEntry',
+            $space,
+            $ct,
+            1,
+            new \DateTimeImmutable('2014-08-11T08:30:42.559Z'),
+            new \DateTimeImmutable('2014-08-12T08:30:42.559Z'),
+            new \DateTimeImmutable('2014-08-13T08:30:42.559Z')
+        ));
+
+        $this->assertEquals($ct, $deletedEntry->getContentType());
     }
 
     /**


### PR DESCRIPTION
Currently it only works when parsing webhook responses, the sync ednpoints omits that data.

Fixes #101