### PR TITLE
Don't attempt to deal with linked fields that are present but empty objects

### DIFF
--- a/src/Delivery/DynamicEntry.php
+++ b/src/Delivery/DynamicEntry.php
@@ -109,7 +109,10 @@ class DynamicEntry extends LocalizedResource implements EntryInterface
         // Since DynamicEntry::getFieldForName manipulates the field name let's make sure we got the correct one
         $fieldName = $fieldConfig->getId();
 
-        if (!isset($this->fields[$fieldName]) || ($fieldConfig->getType() === 'Link' && empty($this->fields[$fieldName]))) {
+        // HACK: Don't attempt to deal with some empty fields
+        if (!isset($this->fields[$fieldName]) || (in_array($fieldConfig->getType(),
+                    ['Array', 'Link']) && empty($this->fields[$fieldName]))
+        ) {
             if ($fieldConfig->getType() === 'Array') {
                 return [];
             }

--- a/src/Delivery/DynamicEntry.php
+++ b/src/Delivery/DynamicEntry.php
@@ -109,7 +109,7 @@ class DynamicEntry extends LocalizedResource implements EntryInterface
         // Since DynamicEntry::getFieldForName manipulates the field name let's make sure we got the correct one
         $fieldName = $fieldConfig->getId();
 
-        if (!isset($this->fields[$fieldName])) {
+        if (!isset($this->fields[$fieldName]) || ($fieldConfig->getType() === 'Link' && empty($this->fields[$fieldName]))) {
             if ($fieldConfig->getType() === 'Array') {
                 return [];
             }


### PR DESCRIPTION
This only happens when using web hooks

Fixes #103, closes #102 because it won't be required for #103