### PR TITLE
Removes @covers and @uses annotations from unit tests.

### DIFF
--- a/tests/Unit/Delivery/ContentTypeFieldTest.php
+++ b/tests/Unit/Delivery/ContentTypeFieldTest.php
@@ -10,18 +10,6 @@ use Contentful\Delivery\ContentTypeField;
 
 class ContentTypeFieldTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @covers Contentful\Delivery\ContentTypeField::__construct
-     * @covers Contentful\Delivery\ContentTypeField::getId
-     * @covers Contentful\Delivery\ContentTypeField::getName
-     * @covers Contentful\Delivery\ContentTypeField::getType
-     * @covers Contentful\Delivery\ContentTypeField::getLinkType
-     * @covers Contentful\Delivery\ContentTypeField::getItemsLinkType
-     * @covers Contentful\Delivery\ContentTypeField::getItemsType
-     * @covers Contentful\Delivery\ContentTypeField::isRequired
-     * @covers Contentful\Delivery\ContentTypeField::isLocalized
-     * @covers Contentful\Delivery\ContentTypeField::isDisabled
-     */
     public function testGetter()
     {
         $field = new ContentTypeField(
@@ -47,10 +35,6 @@ class ContentTypeFieldTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(false, $field->isDisabled());
     }
 
-    /**
-     * @covers Contentful\Delivery\ContentTypeField::__construct
-     * @covers Contentful\Delivery\ContentTypeField::jsonSerialize
-     */
     public function testJsonSerialize()
     {
         $field1 = new ContentTypeField(

--- a/tests/Unit/Delivery/ContentTypeTest.php
+++ b/tests/Unit/Delivery/ContentTypeTest.php
@@ -13,30 +13,6 @@ use Contentful\Delivery\SystemProperties;
 
 class ContentTypeTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @covers Contentful\Delivery\ContentType::__construct
-     * @covers Contentful\Delivery\ContentType::getId
-     * @covers Contentful\Delivery\ContentType::getName
-     * @covers Contentful\Delivery\ContentType::getDescription
-     * @covers Contentful\Delivery\ContentType::getSpace
-     * @covers Contentful\Delivery\ContentType::getDisplayField
-     * @covers Contentful\Delivery\ContentType::getCreatedAt
-     * @covers Contentful\Delivery\ContentType::getUpdatedAt
-     * @covers Contentful\Delivery\ContentType::getRevision
-     * @covers Contentful\Delivery\ContentType::getField
-     * @covers Contentful\Delivery\ContentType::getFields
-     *
-     * @uses Contentful\Delivery\SystemProperties::__construct
-     * @uses Contentful\Delivery\SystemProperties::getId
-     * @uses Contentful\Delivery\SystemProperties::getSpace
-     * @uses Contentful\Delivery\SystemProperties::getCreatedAt
-     * @uses Contentful\Delivery\SystemProperties::getUpdatedAt
-     * @uses Contentful\Delivery\SystemProperties::getRevision
-     *
-     * @uses Contentful\Delivery\ContentTypeField::__construct
-     * @uses Contentful\Delivery\ContentTypeField::getId
-     * @uses Contentful\Delivery\ContentTypeField::getName
-     */
     public function testGetter()
     {
         $space = $this->getMockBuilder(Space::class)
@@ -74,18 +50,6 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($displayField, $fields['name']);
     }
 
-    /**
-     * @covers Contentful\Delivery\ContentType::__construct
-     * @covers Contentful\Delivery\ContentType::getDescription
-     * @covers Contentful\Delivery\ContentType::getField
-     * @covers Contentful\Delivery\ContentType::getDisplayField
-     *
-     * @uses Contentful\Delivery\SystemProperties::__construct
-     * @uses Contentful\Delivery\SystemProperties::getId
-     *
-     * @uses Contentful\Delivery\ContentTypeField::__construct
-     * @uses Contentful\Delivery\ContentTypeField::getId
-     */
     public function testGetterNotExisting()
     {
         $space = $this->getMockBuilder(Space::class)
@@ -108,23 +72,6 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($contentType->getDisplayField());
     }
 
-    /**
-     * @covers Contentful\Delivery\ContentType::__construct
-     * @covers Contentful\Delivery\ContentType::jsonSerialize
-     *
-     * @uses Contentful\Delivery\SystemProperties::__construct
-     * @uses Contentful\Delivery\SystemProperties::getId
-     * @uses Contentful\Delivery\SystemProperties::jsonSerialize
-     * @uses Contentful\Delivery\SystemProperties::formatDateForJson
-     *
-     * @uses Contentful\Delivery\ContentTypeField::__construct
-     * @uses Contentful\Delivery\ContentTypeField::getId
-     * @uses Contentful\Delivery\ContentTypeField::jsonSerialize
-     *
-     *
-     * For some reason phpunit claims this method is executed, no idea why.
-     * @uses Contentful\Delivery\SystemProperties::getCreatedAt
-     */
     public function testJsonSerialize()
     {
         $space = $this->getMockBuilder(Space::class)

--- a/tests/Unit/Delivery/LocaleTest.php
+++ b/tests/Unit/Delivery/LocaleTest.php
@@ -10,13 +10,6 @@ use Contentful\Delivery\Locale;
 
 class LocaleTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @covers \Contentful\Delivery\Locale::__construct
-     * @covers \Contentful\Delivery\Locale::getCode
-     * @covers \Contentful\Delivery\Locale::getName
-     * @covers \Contentful\Delivery\Locale::getFallbackCode
-     * @covers \Contentful\Delivery\Locale::isDefault
-     */
     public function testGetters()
     {
         $code = 'en-US';
@@ -31,20 +24,12 @@ class LocaleTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($default, $locale->isDefault());
     }
 
-    /**
-     * @covers \Contentful\Delivery\Locale::__construct
-     * @covers \Contentful\Delivery\Locale::isDefault
-     */
     public function testWithDefault()
     {
         $locale = new Locale('en-US', 'English (United States)', null);
         $this->assertFalse($locale->isDefault());
     }
 
-    /**
-     * @covers \Contentful\Delivery\Locale::__construct
-     * @covers \Contentful\Delivery\Locale::jsonSerialize
-     */
     public function testJsonSerialization()
     {
         $locale = new Locale('en-US', 'English (United States)', null);

--- a/tests/Unit/Delivery/LocalizedResourceTest.php
+++ b/tests/Unit/Delivery/LocalizedResourceTest.php
@@ -11,14 +11,6 @@ use Contentful\Delivery\Locale;
 
 class LocalizedResourceTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @covers Contentful\Delivery\LocalizedResource::__construct
-     * @covers Contentful\Delivery\LocalizedResource::getLocale
-     *
-     * @uses Contentful\Delivery\Locale::__construct
-     * @uses Contentful\Delivery\Locale::getCode
-     * @uses Contentful\Delivery\Locale::isDefault
-     */
     public function testGetDefaultLocale()
     {
         $resource = new ConcreteLocalizedResource([
@@ -29,15 +21,6 @@ class LocalizedResourceTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('en-US', $resource->getLocale());
     }
 
-    /**
-     * @covers Contentful\Delivery\LocalizedResource::__construct
-     * @covers Contentful\Delivery\LocalizedResource::setLocale
-     * @covers Contentful\Delivery\LocalizedResource::getLocale
-     *
-     * @uses Contentful\Delivery\Locale::__construct
-     * @uses Contentful\Delivery\Locale::getCode
-     * @uses Contentful\Delivery\Locale::isDefault
-     */
     public function testSetGetLocaleString()
     {
         $resource = new ConcreteLocalizedResource([
@@ -49,15 +32,6 @@ class LocalizedResourceTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('de-DE', $resource->getLocale());
     }
 
-    /**
-     * @covers Contentful\Delivery\LocalizedResource::__construct
-     * @covers Contentful\Delivery\LocalizedResource::setLocale
-     * @covers Contentful\Delivery\LocalizedResource::getLocale
-     *
-     * @uses Contentful\Delivery\Locale::__construct
-     * @uses Contentful\Delivery\Locale::getCode
-     * @uses Contentful\Delivery\Locale::isDefault
-     */
     public function testSetGetLocaleObject()
     {
         $deLocale = new Locale('de-DE', 'German (Germany)', 'en-US');
@@ -72,13 +46,6 @@ class LocalizedResourceTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Contentful\Delivery\LocalizedResource::__construct
-     * @covers Contentful\Delivery\LocalizedResource::setLocale
-     *
-     * @uses Contentful\Delivery\Locale::__construct
-     * @uses Contentful\Delivery\Locale::getCode
-     * @uses Contentful\Delivery\Locale::isDefault
-     *
      * @expectedException        \InvalidArgumentException
      * @expectedExceptionMessage Trying to switch to invalid locale fr-FR. Available locales are de-DE, en-US.
      */
@@ -92,14 +59,6 @@ class LocalizedResourceTest extends \PHPUnit_Framework_TestCase
         $resource->setLocale('fr-FR');
     }
 
-    /**
-     * @covers Contentful\Delivery\LocalizedResource::__construct
-     * @covers Contentful\Delivery\LocalizedResource::getLocaleFromInput
-     *
-     * @uses Contentful\Delivery\Locale::__construct
-     * @uses Contentful\Delivery\Locale::getCode
-     * @uses Contentful\Delivery\Locale::isDefault
-     */
     public function testGetLocaleFromInputDefault()
     {
         $resource = new ConcreteLocalizedResource([
@@ -110,14 +69,6 @@ class LocalizedResourceTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('en-US', $resource->getLocaleFromInput());
     }
 
-    /**
-     * @covers Contentful\Delivery\LocalizedResource::__construct
-     * @covers Contentful\Delivery\LocalizedResource::getLocaleFromInput
-     *
-     * @uses Contentful\Delivery\Locale::__construct
-     * @uses Contentful\Delivery\Locale::getCode
-     * @uses Contentful\Delivery\Locale::isDefault
-     */
     public function testGetLocaleFromInputString()
     {
         $resource = new ConcreteLocalizedResource([
@@ -128,14 +79,6 @@ class LocalizedResourceTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('de-DE', $resource->getLocaleFromInput('de-DE'));
     }
 
-    /**
-     * @covers Contentful\Delivery\LocalizedResource::__construct
-     * @covers Contentful\Delivery\LocalizedResource::getLocaleFromInput
-     *
-     * @uses Contentful\Delivery\Locale::__construct
-     * @uses Contentful\Delivery\Locale::getCode
-     * @uses Contentful\Delivery\Locale::isDefault
-     */
     public function testGetLocaleFromInputObject()
     {
         $deLocale = new Locale('de-DE', 'German (Germany)', 'en-US');
@@ -149,13 +92,6 @@ class LocalizedResourceTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Contentful\Delivery\LocalizedResource::__construct
-     * @covers Contentful\Delivery\LocalizedResource::getLocaleFromInput
-     *
-     * @uses Contentful\Delivery\Locale::__construct
-     * @uses Contentful\Delivery\Locale::getCode
-     * @uses Contentful\Delivery\Locale::isDefault
-     *
      * @expectedException        \InvalidArgumentException
      * @expectedExceptionMessage Trying to use invalid locale en-GB. Available locales are de-DE, en-US.
      */

--- a/tests/Unit/Delivery/QueryTest.php
+++ b/tests/Unit/Delivery/QueryTest.php
@@ -10,13 +10,6 @@ use Contentful\Delivery\Query;
 
 class QueryTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @covers Contentful\Delivery\Query::__construct
-     * @covers Contentful\Delivery\Query::setInclude
-     * @covers Contentful\Delivery\Query::getQueryData
-     * @covers Contentful\Query::getQueryData
-     * @covers Contentful\Query::getQueryString
-     */
     public function testQueryStringInclude()
     {
         $query = new Query;
@@ -25,13 +18,6 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('include=50', $query->getQueryString());
     }
 
-    /**
-     * @covers Contentful\Delivery\Query::__construct
-     * @covers Contentful\Delivery\Query::setLocale
-     * @covers Contentful\Delivery\Query::getQueryData
-     * @covers Contentful\Query::getQueryData
-     * @covers Contentful\Query::getQueryString
-     */
     public function testQueryStringLocale()
     {
         $query = new Query;

--- a/tests/Unit/Delivery/SpaceTest.php
+++ b/tests/Unit/Delivery/SpaceTest.php
@@ -12,20 +12,6 @@ use Contentful\Delivery\SystemProperties;
 
 class SpaceTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @covers Contentful\Delivery\Space::__construct
-     * @covers Contentful\Delivery\Space::getId
-     * @covers Contentful\Delivery\Space::getName
-     * @uses Contentful\Delivery\Space::getLocale
-     * @covers Contentful\Delivery\Space::getLocales
-     * @covers Contentful\Delivery\Space::getDefaultLocale
-     *
-     * @uses Contentful\Delivery\Locale::__construct
-     * @uses Contentful\Delivery\Locale::isDefault
-     * @uses Contentful\Delivery\Locale::getCode
-     * @uses Contentful\Delivery\SystemProperties::__construct
-     * @uses Contentful\Delivery\SystemProperties::getId
-     */
     public function testGetter()
     {
         $localeDe = new Locale('de-DE', 'German (Germany)', null, true);
@@ -41,18 +27,6 @@ class SpaceTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($localeEn, $space->getLocale('en-US'));
     }
 
-    /**
-     * @covers Contentful\Delivery\Space::__construct
-     * @covers Contentful\Delivery\Space::getId
-     * @covers Contentful\Delivery\Space::jsonSerialize
-     *
-     * @uses Contentful\Delivery\Locale::__construct
-     * @uses Contentful\Delivery\Locale::isDefault
-     * @uses Contentful\Delivery\Locale::getCode
-     * @uses Contentful\Delivery\Locale::jsonSerialize
-     * @uses Contentful\Delivery\SystemProperties::__construct
-     * @uses Contentful\Delivery\SystemProperties::jsonSerialize
-     */
     public function testJsonSerialization()
     {
         $localeDe = new Locale('de-DE', 'German (Germany)', null, true);

--- a/tests/Unit/Delivery/Synchronization/DeletedResourceTest.php
+++ b/tests/Unit/Delivery/Synchronization/DeletedResourceTest.php
@@ -14,23 +14,6 @@ use Contentful\Delivery\SystemProperties;
 
 class DeletedResourceTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @covers Contentful\Delivery\Synchronization\DeletedResource::__construct
-     * @covers Contentful\Delivery\Synchronization\DeletedResource::getId
-     * @covers Contentful\Delivery\Synchronization\DeletedResource::getSpace
-     * @covers Contentful\Delivery\Synchronization\DeletedResource::getRevision
-     * @covers Contentful\Delivery\Synchronization\DeletedResource::getCreatedAt
-     * @covers Contentful\Delivery\Synchronization\DeletedResource::getUpdatedAt
-     * @covers Contentful\Delivery\Synchronization\DeletedResource::getDeletedAt
-     *
-     * @uses Contentful\Delivery\SystemProperties::__construct
-     * @uses Contentful\Delivery\SystemProperties::getId
-     * @uses Contentful\Delivery\SystemProperties::getSpace
-     * @uses Contentful\Delivery\SystemProperties::getRevision
-     * @uses Contentful\Delivery\SystemProperties::getCreatedAt
-     * @uses Contentful\Delivery\SystemProperties::getUpdatedAt
-     * @uses Contentful\Delivery\SystemProperties::getDeletedAt
-     */
     public function testGetter()
     {
         $space = $this->getMockBuilder(Space::class)
@@ -93,14 +76,6 @@ class DeletedResourceTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($ct, $deletedEntry->getContentType());
     }
 
-    /**
-     * @covers Contentful\Delivery\Synchronization\DeletedResource::__construct
-     * @covers Contentful\Delivery\Synchronization\DeletedResource::jsonSerialize
-     *
-     * @uses Contentful\Delivery\SystemProperties::__construct
-     * @uses Contentful\Delivery\SystemProperties::jsonSerialize
-     * @uses Contentful\Delivery\SystemProperties::formatDateForJson
-     */
     public function testJsonSerialize()
     {
         $space = $this->getMockBuilder(Space::class)

--- a/tests/Unit/Delivery/Synchronization/QueryTest.php
+++ b/tests/Unit/Delivery/Synchronization/QueryTest.php
@@ -11,11 +11,6 @@ use Contentful\Delivery\Synchronization\Query;
 
 class QueryTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @covers Contentful\Delivery\Synchronization\Query::__construct
-     * @covers Contentful\Delivery\Synchronization\Query::getQueryData
-     * @covers Contentful\Delivery\Synchronization\Query::getQueryString
-     */
     public function testFilterWithNoOptions()
     {
         $queryBuilder = new Query;
@@ -24,9 +19,6 @@ class QueryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Contentful\Delivery\Synchronization\Query::__construct
-     * @covers Contentful\Delivery\Synchronization\Query::setType
-     *
      * @expectedException \InvalidArgumentException
      */
     public function testSetTypeInvalidValue()
@@ -36,11 +28,6 @@ class QueryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Contentful\Delivery\Synchronization\Query::__construct
-     * @covers Contentful\Delivery\Synchronization\Query::setType
-     * @covers Contentful\Delivery\Synchronization\Query::getQueryData
-     * @covers Contentful\Delivery\Synchronization\Query::getQueryString
-     *
      * @uses Contentful\Delivery\Synchronization\Query::setType
      */
     public function testFilterByType()
@@ -52,10 +39,6 @@ class QueryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Contentful\Delivery\Synchronization\Query::__construct
-     * @covers Contentful\Delivery\Synchronization\Query::setContentType
-     * @covers Contentful\Delivery\Synchronization\Query::getQueryString
-     *
      * @uses Contentful\Delivery\Synchronization\Query::getQueryData
      * @uses Contentful\Delivery\Synchronization\Query::setType
      */
@@ -75,11 +58,6 @@ class QueryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Contentful\Delivery\Synchronization\Query::__construct
-     * @covers Contentful\Delivery\Synchronization\Query::setContentType
-     * @covers Contentful\Delivery\Synchronization\Query::getQueryData
-     * @covers Contentful\Delivery\Synchronization\Query::getQueryString
-     *
      * @uses Contentful\Delivery\Synchronization\Query::setType
      */
     public function testFilterByContentType()

--- a/tests/Unit/Delivery/Synchronization/ResultTest.php
+++ b/tests/Unit/Delivery/Synchronization/ResultTest.php
@@ -10,12 +10,6 @@ use Contentful\Delivery\Synchronization\Result;
 
 class ResultTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @covers Contentful\Delivery\Synchronization\Result::__construct
-     * @covers Contentful\Delivery\Synchronization\Result::getItems
-     * @covers Contentful\Delivery\Synchronization\Result::getToken
-     * @covers Contentful\Delivery\Synchronization\Result::isDone
-     */
     public function testGetter()
     {
         $arr = [];

--- a/tests/Unit/Delivery/SystemPropertiesTest.php
+++ b/tests/Unit/Delivery/SystemPropertiesTest.php
@@ -12,17 +12,6 @@ use Contentful\Delivery\ContentType;
 
 class SystemPropertiesTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @covers Contentful\Delivery\SystemProperties::__construct
-     * @covers Contentful\Delivery\SystemProperties::getId
-     * @covers Contentful\Delivery\SystemProperties::getType
-     * @covers Contentful\Delivery\SystemProperties::getSpace
-     * @covers Contentful\Delivery\SystemProperties::getContentType
-     * @covers Contentful\Delivery\SystemProperties::getRevision
-     * @covers Contentful\Delivery\SystemProperties::getCreatedAt
-     * @covers Contentful\Delivery\SystemProperties::getUpdatedAt
-     * @covers Contentful\Delivery\SystemProperties::getDeletedAt
-     */
     public function testGetter()
     {
         $space = $this->getMockBuilder(Space::class)
@@ -54,11 +43,6 @@ class SystemPropertiesTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(new \DateTimeImmutable('2014-08-13T08:30:42.559Z'), $sys->getDeletedAt());
     }
 
-    /**
-     * @covers Contentful\Delivery\SystemProperties::__construct
-     * @covers Contentful\Delivery\SystemProperties::jsonSerialize
-     * @covers Contentful\Delivery\SystemProperties::formatDateForJson
-     */
     public function testJsonSerializeSpace()
     {
         $sys = new SystemProperties('123', 'Space');
@@ -69,11 +53,6 @@ class SystemPropertiesTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @covers Contentful\Delivery\SystemProperties::__construct
-     * @covers Contentful\Delivery\SystemProperties::jsonSerialize
-     * @covers Contentful\Delivery\SystemProperties::formatDateForJson
-     */
     public function testJsonSerializeDeletedResource()
     {
         $space = $this->getMockBuilder(Space::class)
@@ -100,11 +79,6 @@ class SystemPropertiesTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @covers Contentful\Delivery\SystemProperties::__construct
-     * @covers Contentful\Delivery\SystemProperties::jsonSerialize
-     * @covers Contentful\Delivery\SystemProperties::formatDateForJson
-     */
     public function testJsonSerializeEntry()
     {
         $space = $this->getMockBuilder(Space::class)

--- a/tests/Unit/FileTest.php
+++ b/tests/Unit/FileTest.php
@@ -25,13 +25,6 @@ class FileTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @covers \Contentful\File::__construct
-     * @covers \Contentful\File::getFileName
-     * @covers \Contentful\File::getContentType
-     * @covers \Contentful\File::getUrl
-     * @covers \Contentful\File::getSize
-     */
     public function testGetter()
     {
         $this->assertEquals('Nyan_cat_250px_frame.png', $this->file->getFileName());
@@ -40,10 +33,6 @@ class FileTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(12273, $this->file->getSize());
     }
 
-    /**
-     * @covers \Contentful\File::__construct
-     * @covers \Contentful\File::jsonSerialize
-     */
     public function testJsonSerialize()
     {
         $this->assertJsonStringEqualsJsonString(

--- a/tests/Unit/ImageFileTest.php
+++ b/tests/Unit/ImageFileTest.php
@@ -28,15 +28,6 @@ class ImageFileTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @covers \Contentful\ImageFile::__construct
-     * @covers \Contentful\ImageFile::getUrl
-     * @covers \Contentful\ImageFile::getWidth
-     * @covers \Contentful\ImageFile::getHeight
-     *
-     * @covers \Contentful\File::__construct
-     * @covers \Contentful\File::getUrl
-     */
     public function testGetter()
     {
         $this->assertEquals('//images.contentful.com/cfexampleapi/4gp6taAwW4CmSgumq2ekUm/9da0cd1936871b8d72343e895a00d611/Nyan_cat_250px_frame.png', $this->file->getUrl());
@@ -44,13 +35,6 @@ class ImageFileTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(250, $this->file->getHeight());
     }
 
-    /**
-     * @covers \Contentful\ImageFile::__construct
-     * @covers \Contentful\ImageFile::getUrl
-     *
-     * @covers \Contentful\File::__construct
-     * @covers \Contentful\File::getUrl
-     */
     public function testWithImageOptions()
     {
         $stub = $this->getMockBuilder(ImageOptions::class)
@@ -66,13 +50,6 @@ class ImageFileTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @covers \Contentful\ImageFile::__construct
-     * @covers \Contentful\ImageFile::jsonSerialize
-     *
-     * @covers \Contentful\File::__construct
-     * @covers \Contentful\File::jsonSerialize
-     */
     public function testJsonSerialize()
     {
         $this->assertJsonStringEqualsJsonString(

--- a/tests/Unit/ImageOptionsTest.php
+++ b/tests/Unit/ImageOptionsTest.php
@@ -10,10 +10,6 @@ use Contentful\ImageOptions;
 
 class ImageOptionsTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @covers \Contentful\ImageOptions::__construct
-     * @covers \Contentful\ImageOptions::getQueryString
-     */
     public function testNoOptions()
     {
         $options = new ImageOptions;
@@ -21,11 +17,6 @@ class ImageOptionsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('', $options->getQueryString());
     }
 
-    /**
-     * @covers \Contentful\ImageOptions::__construct
-     * @covers \Contentful\ImageOptions::setWidth
-     * @covers \Contentful\ImageOptions::getWidth
-     */
     public function testGetSetWidth()
     {
         $width = 50;
@@ -36,11 +27,6 @@ class ImageOptionsTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($width, $options->getWidth());
     }
 
-    /**
-     * @covers \Contentful\ImageOptions::__construct
-     * @covers \Contentful\ImageOptions::setWidth
-     * @covers \Contentful\ImageOptions::getWidth
-     */
     public function testGetSetWidthNull()
     {
         $width = null;
@@ -52,10 +38,6 @@ class ImageOptionsTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \Contentful\ImageOptions::__construct
-     * @covers \Contentful\ImageOptions::setWidth
-     * @covers \Contentful\ImageOptions::getWidth
-     *
      * @expectedException \InvalidArgumentException
      */
     public function testSetWidthNegative()
@@ -64,11 +46,6 @@ class ImageOptionsTest extends \PHPUnit_Framework_TestCase
         $options->setWidth(-50);
     }
 
-    /**
-     * @covers \Contentful\ImageOptions::__construct
-     * @covers \Contentful\ImageOptions::setWidth
-     * @covers \Contentful\ImageOptions::getQueryString
-     */
     public function testQueryWidth()
     {
         $options = new ImageOptions;
@@ -77,11 +54,6 @@ class ImageOptionsTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('w=50', $options->getQueryString());
     }
 
-    /**
-     * @covers \Contentful\ImageOptions::__construct
-     * @covers \Contentful\ImageOptions::setHeight
-     * @covers \Contentful\ImageOptions::getHeight
-     */
     public function testGetSetHeight()
     {
         $height = 50;
@@ -92,11 +64,6 @@ class ImageOptionsTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($height, $options->getHeight());
     }
 
-    /**
-     * @covers \Contentful\ImageOptions::__construct
-     * @covers \Contentful\ImageOptions::setHeight
-     * @covers \Contentful\ImageOptions::getHeight
-     */
     public function testGetSetHeightNull()
     {
         $height = null;
@@ -108,10 +75,6 @@ class ImageOptionsTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \Contentful\ImageOptions::__construct
-     * @covers \Contentful\ImageOptions::setHeight
-     * @covers \Contentful\ImageOptions::getHeight
-     *
      * @expectedException \InvalidArgumentException
      */
     public function testSetHeightNegative()
@@ -120,11 +83,6 @@ class ImageOptionsTest extends \PHPUnit_Framework_TestCase
         $options->setHeight(-50);
     }
 
-    /**
-     * @covers \Contentful\ImageOptions::__construct
-     * @covers \Contentful\ImageOptions::setHeight
-     * @covers \Contentful\ImageOptions::getQueryString
-     */
     public function testQueryHeight()
     {
         $options = new ImageOptions;
@@ -133,11 +91,6 @@ class ImageOptionsTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('h=50', $options->getQueryString());
     }
 
-    /**
-     * @covers \Contentful\ImageOptions::__construct
-     * @covers \Contentful\ImageOptions::setFormat
-     * @covers \Contentful\ImageOptions::getFormat
-     */
     public function testGetSetFormat()
     {
         $format = 'png';
@@ -148,11 +101,6 @@ class ImageOptionsTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($format, $options->getFormat());
     }
 
-    /**
-     * @covers \Contentful\ImageOptions::__construct
-     * @covers \Contentful\ImageOptions::setFormat
-     * @covers \Contentful\ImageOptions::getFormat
-     */
     public function testGetSetFormatNull()
     {
         $format = null;
@@ -164,9 +112,6 @@ class ImageOptionsTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \Contentful\ImageOptions::__construct
-     * @covers \Contentful\ImageOptions::setFormat
-     *
      * @expectedException \InvalidArgumentException
      */
     public function testSetFormatInvalid()
@@ -175,11 +120,6 @@ class ImageOptionsTest extends \PHPUnit_Framework_TestCase
         $options->setFormat('invalid');
     }
 
-    /**
-     * @covers \Contentful\ImageOptions::__construct
-     * @covers \Contentful\ImageOptions::setFormat
-     * @covers \Contentful\ImageOptions::getQueryString
-     */
     public function testQueryFormat()
     {
         $options = new ImageOptions;
@@ -188,11 +128,6 @@ class ImageOptionsTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('fm=png', $options->getQueryString());
     }
 
-    /**
-     * @covers \Contentful\ImageOptions::__construct
-     * @covers \Contentful\ImageOptions::setQuality
-     * @covers \Contentful\ImageOptions::getQuality
-     */
     public function testGetSetQuality()
     {
         $quality = 50;
@@ -203,11 +138,6 @@ class ImageOptionsTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($quality, $options->getQuality());
     }
 
-    /**
-     * @covers \Contentful\ImageOptions::__construct
-     * @covers \Contentful\ImageOptions::setQuality
-     * @covers \Contentful\ImageOptions::getQuality
-     */
     public function testGetSetQualityNull()
     {
         $quality = null;
@@ -219,10 +149,6 @@ class ImageOptionsTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \Contentful\ImageOptions::__construct
-     * @covers \Contentful\ImageOptions::setQuality
-     * @covers \Contentful\ImageOptions::getQuality
-     *
      * @expectedException \InvalidArgumentException
      */
     public function testSetQualityNegative()
@@ -231,11 +157,6 @@ class ImageOptionsTest extends \PHPUnit_Framework_TestCase
         $options->setQuality(-50);
     }
 
-    /**
-     * @covers \Contentful\ImageOptions::__construct
-     * @covers \Contentful\ImageOptions::setQuality
-     * @covers \Contentful\ImageOptions::getQueryString
-     */
     public function testQueryQuality()
     {
         $options = new ImageOptions;
@@ -244,13 +165,6 @@ class ImageOptionsTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('fm=jpg&q=50', $options->getQueryString());
     }
 
-    /**
-     * @covers \Contentful\ImageOptions::__construct
-     * @covers \Contentful\ImageOptions::setFormat
-     * @covers \Contentful\ImageOptions::setQuality
-     * @covers \Contentful\ImageOptions::getFormat
-     * @covers \Contentful\ImageOptions::getQueryString
-     */
     public function testQueryQualityOverridesFormat()
     {
         $options = new ImageOptions;
@@ -262,21 +176,12 @@ class ImageOptionsTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('fm=jpg&q=50', $options->getQueryString());
     }
 
-    /**
-     * @covers \Contentful\ImageOptions::__construct
-     * @covers \Contentful\ImageOptions::isProgressive
-     */
     public function testGetProgressiveDefault()
     {
         $options = new ImageOptions;
         $this->assertFalse($options->isProgressive());
     }
 
-    /**
-     * @covers \Contentful\ImageOptions::__construct
-     * @covers \Contentful\ImageOptions::setProgressive
-     * @covers \Contentful\ImageOptions::isProgressive
-     */
     public function testGetSetProgressive()
     {
         $options = new ImageOptions;
@@ -285,11 +190,6 @@ class ImageOptionsTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($options->isProgressive());
     }
 
-    /**
-     * @covers \Contentful\ImageOptions::__construct
-     * @covers \Contentful\ImageOptions::setProgressive
-     * @covers \Contentful\ImageOptions::getQueryString
-     */
     public function testQueryProgressive()
     {
         $options = new ImageOptions;
@@ -298,13 +198,6 @@ class ImageOptionsTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('fm=jpg&fl=progressive', $options->getQueryString());
     }
 
-    /**
-     * @covers \Contentful\ImageOptions::__construct
-     * @covers \Contentful\ImageOptions::setFormat
-     * @covers \Contentful\ImageOptions::setProgressive
-     * @covers \Contentful\ImageOptions::getFormat
-     * @covers \Contentful\ImageOptions::getQueryString
-     */
     public function testQueryProgressiveOverridesFormat()
     {
         $options = new ImageOptions;
@@ -316,11 +209,6 @@ class ImageOptionsTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('fm=jpg&fl=progressive', $options->getQueryString());
     }
 
-    /**
-     * @covers \Contentful\ImageOptions::__construct
-     * @covers \Contentful\ImageOptions::setResizeFit
-     * @covers \Contentful\ImageOptions::getResizeFit
-     */
     public function testGetSetResizeFit()
     {
         $options = new ImageOptions;
@@ -330,9 +218,6 @@ class ImageOptionsTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \Contentful\ImageOptions::__construct
-     * @covers \Contentful\ImageOptions::setResizeFit
-     *
      * @expectedException \InvalidArgumentException
      */
     public function testSetResizeFitInvalid()
@@ -341,11 +226,6 @@ class ImageOptionsTest extends \PHPUnit_Framework_TestCase
         $options->setResizeFit('invalid');
     }
 
-    /**
-     * @covers \Contentful\ImageOptions::__construct
-     * @covers \Contentful\ImageOptions::setResizeFit
-     * @covers \Contentful\ImageOptions::getQueryString
-     */
     public function testQueryResizeFit()
     {
         $options = new ImageOptions;
@@ -354,11 +234,6 @@ class ImageOptionsTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('fit=pad', $options->getQueryString());
     }
 
-    /**
-     * @covers \Contentful\ImageOptions::__construct
-     * @covers \Contentful\ImageOptions::setResizeFocus
-     * @covers \Contentful\ImageOptions::getResizeFocus
-     */
     public function testGetSetResizeFocus()
     {
         $options = new ImageOptions;
@@ -368,9 +243,6 @@ class ImageOptionsTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \Contentful\ImageOptions::__construct
-     * @covers \Contentful\ImageOptions::setResizeFocus
-     *
      * @expectedException \InvalidArgumentException
      */
     public function testSetResizeFocusInvalid()
@@ -379,12 +251,6 @@ class ImageOptionsTest extends \PHPUnit_Framework_TestCase
         $options->setResizeFocus('invalid');
     }
 
-    /**
-     * @covers \Contentful\ImageOptions::__construct
-     * @covers \Contentful\ImageOptions::setResizeFit
-     * @covers \Contentful\ImageOptions::setResizeFocus
-     * @covers \Contentful\ImageOptions::getQueryString
-     */
     public function testQueryResizeFocus()
     {
         $options = new ImageOptions;
@@ -394,11 +260,6 @@ class ImageOptionsTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('fit=thumb&f=top', $options->getQueryString());
     }
 
-    /**
-     * @covers \Contentful\ImageOptions::__construct
-     * @covers \Contentful\ImageOptions::setResizeFocus
-     * @covers \Contentful\ImageOptions::getQueryString
-     */
     public function testQueryResizeFocusIgnoredWithoutFit()
     {
         $options = new ImageOptions;
@@ -407,11 +268,6 @@ class ImageOptionsTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('', $options->getQueryString());
     }
 
-    /**
-     * @covers \Contentful\ImageOptions::__construct
-     * @covers \Contentful\ImageOptions::setRadius
-     * @covers \Contentful\ImageOptions::getRadius
-     */
     public function testGetSetRadius()
     {
         $options = new ImageOptions;
@@ -421,9 +277,6 @@ class ImageOptionsTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \Contentful\ImageOptions::__construct
-     * @covers \Contentful\ImageOptions::setRadius
-     *
      * @expectedException \InvalidArgumentException
      */
     public function testSetRadiusNegative()
@@ -432,11 +285,6 @@ class ImageOptionsTest extends \PHPUnit_Framework_TestCase
         $options->setRadius(-13.2);
     }
 
-    /**
-     * @covers \Contentful\ImageOptions::__construct
-     * @covers \Contentful\ImageOptions::setRadius
-     * @covers \Contentful\ImageOptions::getQueryString
-     */
     public function testQueryRadius()
     {
         $options = new ImageOptions;
@@ -445,11 +293,6 @@ class ImageOptionsTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('r=50.3', $options->getQueryString());
     }
 
-    /**
-     * @covers \Contentful\ImageOptions::__construct
-     * @covers \Contentful\ImageOptions::setBackgroundColor
-     * @covers \Contentful\ImageOptions::getBackgroundColor
-     */
     public function testGetSetBackgroundColorSixDigits()
     {
         $options = new ImageOptions;
@@ -458,11 +301,6 @@ class ImageOptionsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('#a0f326', $options->getBackgroundColor());
     }
 
-    /**
-     * @covers \Contentful\ImageOptions::__construct
-     * @covers \Contentful\ImageOptions::setBackgroundColor
-     * @covers \Contentful\ImageOptions::getBackgroundColor
-     */
     public function testGetSetBackgroundColorThreeDigits()
     {
         $options = new ImageOptions;
@@ -471,11 +309,6 @@ class ImageOptionsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('#0AF', $options->getBackgroundColor());
     }
 
-    /**
-     * @covers \Contentful\ImageOptions::__construct
-     * @covers \Contentful\ImageOptions::setBackgroundColor
-     * @covers \Contentful\ImageOptions::getBackgroundColor
-     */
     public function testGetSetBackgroundColorUpperCase()
     {
         $options = new ImageOptions;
@@ -485,9 +318,6 @@ class ImageOptionsTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \Contentful\ImageOptions::__construct
-     * @covers \Contentful\ImageOptions::setBackgroundColor
-     *
      * @expectedException \InvalidArgumentException
      */
     public function testSetBackgroundColorTooShort()
@@ -497,9 +327,6 @@ class ImageOptionsTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \Contentful\ImageOptions::__construct
-     * @covers \Contentful\ImageOptions::setBackgroundColor
-     *
      * @expectedException \InvalidArgumentException
      */
     public function testSetBackgroundInvalidCharacter()
@@ -509,9 +336,6 @@ class ImageOptionsTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \Contentful\ImageOptions::__construct
-     * @covers \Contentful\ImageOptions::setBackgroundColor
-     *
      * @expectedException \InvalidArgumentException
      */
     public function testSetBackgroundNoHash()
@@ -520,12 +344,6 @@ class ImageOptionsTest extends \PHPUnit_Framework_TestCase
         $options->setBackgroundColor('A0F326');
     }
 
-    /**
-     * @covers \Contentful\ImageOptions::__construct
-     * @covers \Contentful\ImageOptions::setResizeFit
-     * @covers \Contentful\ImageOptions::setBackgroundColor
-     * @covers \Contentful\ImageOptions::getQueryString
-     */
     public function testQueryBackgroundColor()
     {
         $options = new ImageOptions;
@@ -535,15 +353,6 @@ class ImageOptionsTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('fit=pad&bg=rgb%3Aa0f326', $options->getQueryString());
     }
 
-    /**
-     * @covers \Contentful\ImageOptions::__construct
-     * @covers \Contentful\ImageOptions::setWidth
-     * @covers \Contentful\ImageOptions::setHeight
-     * @covers \Contentful\ImageOptions::setFormat
-     * @covers \Contentful\ImageOptions::setQuality
-     * @covers \Contentful\ImageOptions::setProgressive
-     * @covers \Contentful\ImageOptions::getQueryString
-     */
     public function testQueryCombined()
     {
         $options = new ImageOptions;

--- a/tests/Unit/LinkTest.php
+++ b/tests/Unit/LinkTest.php
@@ -10,11 +10,6 @@ use Contentful\Link;
 
 class LinkTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @covers \Contentful\Link::__construct
-     * @covers \Contentful\Link::getId
-     * @covers \Contentful\Link::getLinkType
-     */
     public function testGetter()
     {
         $link = new Link('123', 'Entry');

--- a/tests/Unit/LocationTest.php
+++ b/tests/Unit/LocationTest.php
@@ -10,11 +10,6 @@ use Contentful\Location;
 
 class LocationTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @covers \Contentful\Location::__construct
-     * @covers \Contentful\Location::getLatitude
-     * @covers \Contentful\Location::getLongitude
-     */
     public function testGetters()
     {
         $lat = 15.0;
@@ -25,10 +20,6 @@ class LocationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($long, $loc->getLongitude());
     }
 
-    /**
-     * @covers \Contentful\Location::__construct
-     * @covers \Contentful\Location::jsonSerialize
-     */
     public function testJsonSerialization()
     {
         $loc = new Location(15.0, 17.8);
@@ -36,10 +27,6 @@ class LocationTest extends \PHPUnit_Framework_TestCase
         $this->assertJsonStringEqualsJsonString('{"lat":15,"long":17.8}', json_encode($loc));
     }
 
-    /**
-     * @covers \Contentful\Location::__construct
-     * @covers \Contentful\Location::queryStringFormatted
-     */
     public function testQueryStringFormatted()
     {
         $loc = new Location(15.0, 17.8);

--- a/tests/Unit/QueryTest.php
+++ b/tests/Unit/QueryTest.php
@@ -16,11 +16,6 @@ class FakeQuery extends Query
 
 class QueryTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @covers Contentful\Query::__construct
-     * @covers Contentful\Query::getQueryData
-     * @covers Contentful\Query::getQueryString
-     */
     public function testFilterWithNoOptions()
     {
         $queryBuilder = new FakeQuery;
@@ -28,12 +23,6 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('', $queryBuilder->getQueryString());
     }
 
-    /**
-     * @covers Contentful\Query::__construct
-     * @covers Contentful\Query::setLimit
-     * @covers Contentful\Query::getQueryData
-     * @covers Contentful\Query::getQueryString
-     */
     public function testFilterWithLimit()
     {
         $queryBuilder = new FakeQuery;
@@ -43,9 +32,6 @@ class QueryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Contentful\Query::__construct
-     * @covers Contentful\Query::setLimit
-     *
      * @expectedException \RangeException
      */
     public function testLimitThrowsOnValueTooLarge()
@@ -55,9 +41,6 @@ class QueryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Contentful\Query::__construct
-     * @covers Contentful\Query::setLimit
-     *
      * @expectedException \RangeException
      */
     public function testLimitThrowsOnValueZero()
@@ -67,9 +50,6 @@ class QueryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Contentful\Query::__construct
-     * @covers Contentful\Query::setLimit
-     *
      * @expectedException \RangeException
      */
     public function testLimitThrowsOnValueNegative()
@@ -78,12 +58,6 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         $queryBuilder->setLimit(-1);
     }
 
-    /**
-     * @covers Contentful\Query::__construct
-     * @covers Contentful\Query::setLimit
-     * @covers Contentful\Query::getQueryData
-     * @covers Contentful\Query::getQueryString
-     */
     public function testLimitSetNull()
     {
         $queryBuilder = new FakeQuery;
@@ -94,12 +68,6 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('', $queryBuilder->getQueryString());
     }
 
-    /**
-     * @covers Contentful\Query::__construct
-     * @covers Contentful\Query::setSkip
-     * @covers Contentful\Query::getQueryData
-     * @covers Contentful\Query::getQueryString
-     */
     public function testFilterWithSkip()
     {
         $queryBuilder = new FakeQuery;
@@ -109,9 +77,6 @@ class QueryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Contentful\Query::__construct
-     * @covers Contentful\Query::setSkip
-     *
      * @expectedException \RangeException
      */
     public function testSkipThrowsOnValueNegative()
@@ -120,12 +85,6 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         $queryBuilder->setSkip(-1);
     }
 
-    /**
-     * @covers Contentful\Query::__construct
-     * @covers Contentful\Query::orderBy
-     * @covers Contentful\Query::getQueryData
-     * @covers Contentful\Query::getQueryString
-     */
     public function testFilterOrderBy()
     {
         $queryBuilder = new FakeQuery;
@@ -134,12 +93,6 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('order=sys.createdAt', $queryBuilder->getQueryString());
     }
 
-    /**
-     * @covers Contentful\Query::__construct
-     * @covers Contentful\Query::orderBy
-     * @covers Contentful\Query::getQueryData
-     * @covers Contentful\Query::getQueryString
-     */
     public function testFilterOrderByReversed()
     {
         $queryBuilder = new FakeQuery;
@@ -148,12 +101,6 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('order=-sys.createdAt', $queryBuilder->getQueryString());
     }
 
-    /**
-     * @covers Contentful\Query::__construct
-     * @covers Contentful\Query::orderBy
-     * @covers Contentful\Query::getQueryData
-     * @covers Contentful\Query::getQueryString
-     */
     public function testFilterOrderByMultiple()
     {
         $queryBuilder = (new FakeQuery)
@@ -163,13 +110,6 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('order=sys.createdAt%2C-sys.updatedAt', $queryBuilder->getQueryString());
     }
 
-    /**
-     * @covers Contentful\Query::__construct
-     * @covers Contentful\Query::setContentType
-     * @covers Contentful\Query::getQueryString
-     *
-     * @uses Contentful\Query::getQueryData
-     */
     public function testGetSetContentTypeFromObject()
     {
         $queryBuilder = new FakeQuery;
@@ -185,12 +125,6 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('content_type=cat', $queryBuilder->getQueryString());
     }
 
-    /**
-     * @covers Contentful\Query::__construct
-     * @covers Contentful\Query::setContentType
-     * @covers Contentful\Query::getQueryData
-     * @covers Contentful\Query::getQueryString
-     */
     public function testFilterByContentType()
     {
         $queryBuilder = new FakeQuery;
@@ -199,12 +133,6 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('content_type=cat', $queryBuilder->getQueryString());
     }
 
-    /**
-     * @covers Contentful\Query::__construct
-     * @covers Contentful\Query::where
-     * @covers Contentful\Query::getQueryData
-     * @covers Contentful\Query::getQueryString
-     */
     public function testWhere()
     {
         $queryBuilder = new FakeQuery;
@@ -213,12 +141,6 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('sys.id=nyancat', $queryBuilder->getQueryString());
     }
 
-    /**
-     * @covers Contentful\Query::__construct
-     * @covers Contentful\Query::where
-     * @covers Contentful\Query::getQueryData
-     * @covers Contentful\Query::getQueryString
-     */
     public function testWhereOperator()
     {
         $queryBuilder = new FakeQuery;
@@ -227,12 +149,6 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('sys.id%5Bne%5D=nyancat', $queryBuilder->getQueryString());
     }
 
-    /**
-     * @covers Contentful\Query::__construct
-     * @covers Contentful\Query::where
-     * @covers Contentful\Query::getQueryData
-     * @covers Contentful\Query::getQueryString
-     */
     public function testWhereDateTime()
     {
         $queryBuilder = new FakeQuery;
@@ -241,12 +157,6 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('sys.updatedAt%5Blte%5D=2013-01-01T00%3A00%3A00%2B00%3A00', $queryBuilder->getQueryString());
     }
 
-    /**
-     * @covers Contentful\Query::__construct
-     * @covers Contentful\Query::where
-     * @covers Contentful\Query::getQueryData
-     * @covers Contentful\Query::getQueryString
-     */
     public function testWhereDateTimeResetsSeconds()
     {
         $queryBuilder = new FakeQuery;
@@ -255,15 +165,6 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('sys.updatedAt%5Blte%5D=2013-01-01T12%3A30%3A00%2B00%3A00', $queryBuilder->getQueryString());
     }
 
-    /**
-     * @covers Contentful\Query::__construct
-     * @covers Contentful\Query::where
-     * @covers Contentful\Query::getQueryData
-     * @covers Contentful\Query::getQueryString
-     *
-     * @uses Contentful\Location::__construct
-     * @uses Contentful\Location::queryStringFormatted
-     */
     public function testWhereLocation()
     {
         $queryBuilder = new FakeQuery;
@@ -272,12 +173,6 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('fields.center%5Bnear%5D=15%2C17.8', $queryBuilder->getQueryString());
     }
 
-    /**
-     * @covers Contentful\Query::__construct
-     * @covers Contentful\Query::where
-     * @covers Contentful\Query::getQueryData
-     * @covers Contentful\Query::getQueryString
-     */
     public function testWhereArray()
     {
         $queryBuilder = new FakeQuery;
@@ -287,9 +182,6 @@ class QueryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Contentful\Query::__construct
-     * @covers Contentful\Query::where
-     *
      * @expectedException \InvalidArgumentException
      */
     public function testWhereUnknownOperator()
@@ -299,9 +191,6 @@ class QueryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Contentful\Query::__construct
-     * @covers Contentful\Query::setMimeTypeGroup
-     *
      * @expectedException \InvalidArgumentException
      */
     public function testSetMimeTypeGroupInvalid()
@@ -310,12 +199,6 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         $queryBuilder->setMimeTypeGroup('invalid');
     }
 
-    /**
-     * @covers Contentful\Query::__construct
-     * @covers Contentful\Query::setMimeTypeGroup
-     * @covers Contentful\Query::getQueryData
-     * @covers Contentful\Query::getQueryString
-     */
     public function testFilterByMimeTypeGroup()
     {
         $queryBuilder = new FakeQuery;
@@ -324,16 +207,6 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('mimetype_group=image', $queryBuilder->getQueryString());
     }
 
-    /**
-     * @covers Contentful\Query::__construct
-     * @covers Contentful\Query::setContentType
-     * @covers Contentful\Query::setLimit
-     * @covers Contentful\Query::setSkip
-     * @covers Contentful\Query::orderBy
-     * @covers Contentful\Query::where
-     * @covers Contentful\Query::getQueryData
-     * @covers Contentful\Query::getQueryString
-     */
     public function testFilterCombined()
     {
         $queryBuilder = new FakeQuery;
@@ -348,13 +221,6 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('limit=150&skip=10&content_type=cat&order=sys.createdAt&sys.id=nyancat&sys.updatedAt%5Blte%5D=2013-01-01T00%3A00%3A00%2B00%3A00', (string) $queryBuilder->getQueryString());
     }
 
-    /**
-     * @covers Contentful\Query::__construct
-     * @covers Contentful\Query::select
-     * @covers Contentful\Query::setContentType
-     * @covers Contentful\Query::getQueryData
-     * @covers Contentful\Query::getQueryString
-     */
     public function testQueryWithSelect()
     {
         $queryBuilder = (new FakeQuery)


### PR DESCRIPTION
They were only used on a subset of tests and they're more trouble than they're worth.