### PR TITLE
Implements the JsonSerialize interface in the Link class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/contentful/contentful.php/compare/1.2.0...HEAD)
 
+### Added
+* `Link` implements the `JsonSerializable` interface. This is done in preparation for the upcoming CMA SDK.
+
 ### Fixed
 * Retrieving a list of entries that contained multiple loops creates too many objects. **[BREAKING]** ([#105](https://github.com/contentful/contentful.php/pull/105))
   The new behavior is, that any entry that appears multiple times in the graph of the response will be the same instance.

--- a/src/Link.php
+++ b/src/Link.php
@@ -9,7 +9,7 @@ namespace Contentful;
 /**
  * A link encodes a reference to a resource.
  */
-class Link
+class Link implements \JsonSerializable
 {
     /**
      * @var string
@@ -55,5 +55,23 @@ class Link
     public function getLinkType()
     {
         return $this->linkType;
+    }
+
+    /**
+     * Returns an object to be used by `json_encode` to serialize objects of this class.
+     *
+     * @return object
+     *
+     * @see http://php.net/manual/en/jsonserializable.jsonserialize.php JsonSerializable::jsonSerialize
+     */
+    public function jsonSerialize()
+    {
+        return (object) [
+            'sys' => (object) [
+                'type' => 'Link',
+                'id' => $this->id,
+                'linkType' => $this->linkType
+            ]
+        ];
     }
 }

--- a/tests/Unit/LinkTest.php
+++ b/tests/Unit/LinkTest.php
@@ -17,4 +17,11 @@ class LinkTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('123', $link->getId());
         $this->assertEquals('Entry', $link->getLinkType());
     }
+
+    public function testJsonSerialize()
+    {
+        $link = new Link('123', 'Entry');
+
+        $this->assertJsonStringEqualsJsonString('{"sys": {"type": "Link", "id": "123", "linkType": "Entry"}}', json_encode($link));
+    }
 }


### PR DESCRIPTION
This is a feature that's required for the upcoming CMA SDK. It's not directly used in the CDA SDK.