### PR TITLE
Added UploadFile class for handling files in unprocessed state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 * `Link` implements the `JsonSerializable` interface. This is done in preparation for the upcoming CMA SDK.
+* `UploadFile` class now manages files which aren't yet processed (for Preview API) **[BREAKING]**. `Contentful\Delivery\Asset::getFile` now returns `Contentful\Delivery\File\FileInterface` instead of one of `File|ImageFile`. If you were type hinting on either one of those, please now use the interface or add `UploadFile` to the possible types.
 
 ### Fixed
 * Retrieving a list of entries that contained multiple loops creates too many objects. **[BREAKING]** ([#105](https://github.com/contentful/contentful.php/pull/105))

--- a/src/Delivery/Asset.php
+++ b/src/Delivery/Asset.php
@@ -6,6 +6,8 @@
 
 namespace Contentful\Delivery;
 
+use Contentful\File\FileInterface;
+
 class Asset extends LocalizedResource implements \JsonSerializable
 {
     /**
@@ -93,7 +95,7 @@ class Asset extends LocalizedResource implements \JsonSerializable
     /**
      * @param  Locale|string|null $locale
      *
-     * @return \Contentful\File\File
+     * @return FileInterface
      *
      * @throws \InvalidArgumentException When $locale is not one of the locales supported by the space.
      */

--- a/src/Delivery/ResourceBuilder.php
+++ b/src/Delivery/ResourceBuilder.php
@@ -15,7 +15,9 @@ use Contentful\Location;
 use Contentful\ResourceArray;
 use Contentful\Link;
 use Contentful\File\File;
+use Contentful\File\FileInterface;
 use Contentful\File\ImageFile;
+use Contentful\File\UploadFile;
 use Contentful\Exception\SpaceMismatchException;
 
 /**
@@ -218,10 +220,14 @@ class ResourceBuilder
      *
      * @param  array $data
      *
-     * @return File|ImageFile
+     * @return FileInterface
      */
     private function buildFile(array $data)
     {
+        if (isset($data['upload'])) {
+            return new UploadFile($data['fileName'], $data['contentType'], $data['upload']);
+        }
+
         $details = $data['details'];
         if (isset($details['image'])) {
             return new ImageFile(

--- a/src/File/FileInterface.php
+++ b/src/File/FileInterface.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @copyright 2015-2017 Contentful GmbH
+ * @license   MIT
+ */
+
+namespace Contentful\File;
+
+interface FileInterface extends \JsonSerializable
+{
+    /**
+     * The name of this file
+     *
+     * @return string
+     *
+     * @api
+     */
+    public function getFileName();
+
+    /**
+     * The Content- (or MIME-)Type of this file.
+     *
+     * @return string
+     *
+     * @api
+     */
+    public function getContentType();
+}

--- a/src/File/UploadFile.php
+++ b/src/File/UploadFile.php
@@ -6,7 +6,7 @@
 
 namespace Contentful\File;
 
-class File implements FileInterface
+class UploadFile implements FileInterface
 {
     /**
      * @var string
@@ -21,27 +21,13 @@ class File implements FileInterface
     /**
      * @var string
      */
-    private $url;
+    private $upload;
 
-    /**
-     * @var int
-     */
-    private $size;
-
-    /**
-     * File constructor.
-     *
-     * @param string $fileName
-     * @param string $contentType
-     * @param string $url
-     * @param int    $size         Size in bytes
-     */
-    public function __construct($fileName, $contentType, $url, $size)
+    public function __construct($fileName, $contentType, $upload)
     {
         $this->fileName = $fileName;
         $this->contentType = $contentType;
-        $this->url = $url;
-        $this->size = $size;
+        $this->upload = $upload;
     }
 
     /**
@@ -69,27 +55,13 @@ class File implements FileInterface
     }
 
     /**
-     * The Url where this file can be retrieved.
-     *
      * @return string
      *
      * @api
      */
-    public function getUrl()
+    public function getUpload()
     {
-        return $this->url;
-    }
-
-    /**
-     * The size in bytes of this file.
-     *
-     * @return int
-     *
-     * @api
-     */
-    public function getSize()
-    {
-        return $this->size;
+        return $this->upload;
     }
 
     /**
@@ -98,18 +70,13 @@ class File implements FileInterface
      * @return object
      *
      * @see http://php.net/manual/en/jsonserializable.jsonserialize.php JsonSerializable::jsonSerialize
-     *
-     * @api
      */
     public function jsonSerialize()
     {
         return (object) [
             'fileName' => $this->fileName,
             'contentType' => $this->contentType,
-            'details' => (object) [
-                'size' => $this->size
-            ],
-            'url' => $this->url
+            'upload' => $this->upload
         ];
     }
 }

--- a/tests/E2E/AssetBasicTest.php
+++ b/tests/E2E/AssetBasicTest.php
@@ -6,6 +6,7 @@
 
 namespace Contentful\Tests\E2E;
 
+use Contentful\File\ImageFile;
 use Contentful\Delivery\Client;
 use Contentful\Delivery\Query;
 use Contentful\ResourceArray;
@@ -54,6 +55,7 @@ class AssetBasicTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf(Asset::class, $asset);
         $this->assertEquals('nyancat', $asset->getId());
+        $this->assertInstanceOf(ImageFile::class, $asset->getFile());
     }
 
     /**

--- a/tests/E2E/UnprocessedFileInPreviewTest.php
+++ b/tests/E2E/UnprocessedFileInPreviewTest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * @copyright 2015-2017 Contentful GmbH
+ * @license   MIT
+ */
+
+namespace Contentful\Tests\E2E;
+
+use Contentful\Delivery\Client;
+use Contentful\File\UploadFile;
+
+class UnprocessedFileInPreviewTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Client
+     */
+    private $client;
+
+    public function setUp()
+    {
+        $this->client = new Client('81c469d7241ca02349388602dfc14107157063a6901c378a56e1835d688970bf', '88dyiqcr7go8', true);
+    }
+
+    /**
+     * @vcr e2e_file_get_unprocessed_file.json
+     */
+    public function testGetUnprocessedFile()
+    {
+        $asset = $this->client->getAsset('147y8r7Fx4YSEWYAQyggui');
+
+        $file = $asset->getFile();
+
+        $this->assertInstanceOf(UploadFile::class, $file);
+        $this->assertEquals('fitzgerald', $file->getFileName());
+        $this->assertEquals(
+            'https://upload.wikimedia.org/wikipedia/commons/5/5c/F_Scott_Fitzgerald_1921.jpg',
+            $file->getUpload()
+        );
+    }
+}

--- a/tests/Unit/Delivery/AssetTest.php
+++ b/tests/Unit/Delivery/AssetTest.php
@@ -11,6 +11,7 @@ use Contentful\File\ImageFile;
 use Contentful\Delivery\Locale;
 use Contentful\Delivery\Space;
 use Contentful\Delivery\SystemProperties;
+use Contentful\File\FileInterface;
 
 class AssetTest extends \PHPUnit_Framework_TestCase
 {
@@ -91,6 +92,7 @@ class AssetTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('Nyan Cat', $asset->getTitle());
         $this->assertEquals('A picture of Nyan Cat', $asset->getDescription());
+        $this->assertInstanceOf(FileInterface::class, $asset->getFile());
         $this->assertSame($this->file, $asset->getFile());
 
         $this->assertEquals('nyancat', $asset->getId());

--- a/tests/Unit/File/UploadFileTest.php
+++ b/tests/Unit/File/UploadFileTest.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @copyright 2015-2017 Contentful GmbH
+ * @license   MIT
+ */
+
+namespace Contentful\Tests\Unit\Delivery;
+
+use Contentful\File\UploadFile;
+
+class UploadFileTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var UploadFile
+     */
+    protected $file;
+
+    public function setUp()
+    {
+        $this->file = new UploadFile(
+            'the_great_gatsby.txt',
+            'image/png',
+            'https://www.example.com/the_great_gatsby.txt'
+        );
+    }
+
+    public function testGetter()
+    {
+        $this->assertEquals('the_great_gatsby.txt', $this->file->getFileName());
+        $this->assertEquals('image/png', $this->file->getContentType());
+        $this->assertEquals('https://www.example.com/the_great_gatsby.txt', $this->file->getUpload());
+    }
+
+    public function testJsonSerialize()
+    {
+        $this->assertJsonStringEqualsJsonString(
+            '{"fileName":"the_great_gatsby.txt","contentType":"image/png","upload": "https://www.example.com/the_great_gatsby.txt"}',
+            json_encode($this->file)
+        );
+    }
+}

--- a/tests/fixtures/e2e_file_get_unprocessed_file.json
+++ b/tests/fixtures/e2e_file_get_unprocessed_file.json
@@ -1,0 +1,79 @@
+[{
+    "request": {
+        "method": "GET",
+        "url": "https:\/\/preview.contentful.com\/spaces\/88dyiqcr7go8\/assets\/147y8r7Fx4YSEWYAQyggui",
+        "headers": {
+            "Host": "preview.contentful.com",
+            "User-Agent": "GuzzleHttp\/6.2.1 curl\/7.51.0 PHP\/7.1.5",
+            "X-Contentful-User-Agent": "sdk contentful.php\/2.0.0-dev; platform PHP\/7.1.5; os macOS;",
+            "Accept": "application\/vnd.contentful.delivery.v1+json",
+            "Accept-Encoding": "gzip",
+            "Authorization": "Bearer 81c469d7241ca02349388602dfc14107157063a6901c378a56e1835d688970bf"
+        }
+    },
+    "response": {
+        "status": {
+            "http_version": "1.1",
+            "code": "200",
+            "message": "OK"
+        },
+        "headers": {
+            "Access-Control-Allow-Headers": "Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent",
+            "Access-Control-Allow-Methods": "GET,HEAD,OPTIONS",
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Expose-Headers": "Etag",
+            "Access-Control-Max-Age": "1728000",
+            "CF-Cache-Name": "content_delivery",
+            "CF-Organization-Id": "3ubGFD1MWA6VgVYbIwSBg8",
+            "CF-Space-Id": "88dyiqcr7go8",
+            "Content-Type": "application\/vnd.contentful.delivery.v1+json",
+            "Date": "Wed, 07 Jun 2017 14:09:18 GMT",
+            "ETag": "\"1b82f483f81355620d50358b16923267\"",
+            "Server": "Contentful",
+            "X-Content-Type-Options": "nosniff",
+            "X-Contentful-Request-Id": "548b9a909d1f6e77748841180111805c",
+            "Content-Length": "612",
+            "Connection": "keep-alive"
+        },
+        "body": "{\n  \"sys\": {\n    \"space\": {\n      \"sys\": {\n        \"type\": \"Link\",\n        \"linkType\": \"Space\",\n        \"id\": \"88dyiqcr7go8\"\n      }\n    },\n    \"type\": \"Asset\",\n    \"id\": \"147y8r7Fx4YSEWYAQyggui\",\n    \"revision\": 0,\n    \"createdAt\": \"2017-06-07T13:03:37.151Z\",\n    \"updatedAt\": \"2017-06-07T13:03:37.161Z\",\n    \"locale\": \"en-US\"\n  },\n  \"fields\": {\n    \"title\": \"Scott Fitzgerald\",\n    \"description\": \"A really cool asset\",\n    \"file\": {\n      \"upload\": \"https:\/\/upload.wikimedia.org\/wikipedia\/commons\/5\/5c\/F_Scott_Fitzgerald_1921.jpg\",\n      \"fileName\": \"fitzgerald\",\n      \"contentType\": \"image\/jpg\"\n    }\n  }\n}\n"
+    }
+},{
+    "request": {
+        "method": "GET",
+        "url": "https:\/\/preview.contentful.com\/spaces\/88dyiqcr7go8\/",
+        "headers": {
+            "Host": "preview.contentful.com",
+            "User-Agent": "GuzzleHttp\/6.2.1 curl\/7.51.0 PHP\/7.1.5",
+            "X-Contentful-User-Agent": "sdk contentful.php\/2.0.0-dev; platform PHP\/7.1.5; os macOS;",
+            "Accept": "application\/vnd.contentful.delivery.v1+json",
+            "Accept-Encoding": "gzip",
+            "Authorization": "Bearer 81c469d7241ca02349388602dfc14107157063a6901c378a56e1835d688970bf"
+        }
+    },
+    "response": {
+        "status": {
+            "http_version": "1.1",
+            "code": "200",
+            "message": "OK"
+        },
+        "headers": {
+            "Access-Control-Allow-Headers": "Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent",
+            "Access-Control-Allow-Methods": "GET,HEAD,OPTIONS",
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Expose-Headers": "Etag",
+            "Access-Control-Max-Age": "1728000",
+            "CF-Cache-Name": "content_delivery",
+            "CF-Organization-Id": "3ubGFD1MWA6VgVYbIwSBg8",
+            "CF-Space-Id": "88dyiqcr7go8",
+            "Content-Type": "application\/vnd.contentful.delivery.v1+json",
+            "Date": "Wed, 07 Jun 2017 14:09:18 GMT",
+            "ETag": "\"5112736b760c64deb2957b99592f5b5f\"",
+            "Server": "Contentful",
+            "X-Content-Type-Options": "nosniff",
+            "X-Contentful-Request-Id": "ad295cb5b89c112a08f28f8ffde886d9",
+            "Content-Length": "233",
+            "Connection": "keep-alive"
+        },
+        "body": "{\n  \"sys\": {\n    \"type\": \"Space\",\n    \"id\": \"88dyiqcr7go8\"\n  },\n  \"name\": \"File States Testing\",\n  \"locales\": [\n    {\n      \"code\": \"en-US\",\n      \"default\": true,\n      \"name\": \"U.S. English\",\n      \"fallbackCode\": null\n    }\n  ]\n}\n"
+    }
+}]


### PR DESCRIPTION
Files can be "hanging" in an _unprocessed_ state, and they are accessible when using the Preview API. This PR adds a `UploadFile` class which is used to handle such files.