### PR TITLE
Fixes badly formatted error messages in the console commands.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Retrieving a list of entries that contained multiple loops creates too many objects. **[BREAKING]** ([#105](https://github.com/contentful/contentful.php/pull/105))
   The new behavior is, that any entry that appears multiple times in the graph of the response will be the same instance.
 * The `contentful` script used to warm up/clear the cache was not marked as a binary in `composer.json` and thus not published to `vendor/bin`.
+* In console commands `<info>` can't be used as part of an Exception message. ([#129](https://github.com/contentful/contentful.php/pull/129))
 
 ### Changed
 * Moved file classes to a sub-namespace `Contentful\File` **[BREAKING]**.

--- a/src/Delivery/Console/ClearCacheCommand.php
+++ b/src/Delivery/Console/ClearCacheCommand.php
@@ -40,12 +40,12 @@ class ClearCacheCommand extends Command
 
         if (!$fs->exists($cacheDir)) {
             throw new \InvalidArgumentException(
-                sprintf("Cache directory '<info>%s</info>' does not exist.", $cacheDir)
+                sprintf("Cache directory '%s' does not exist.", $cacheDir)
             );
         }
         if (!is_writable($cacheDir)) {
             throw new \InvalidArgumentException(
-                sprintf("Cache directory '<info>%s</info>' can not be written to.", $cacheDir)
+                sprintf("Cache directory '%s' can not be written to.", $cacheDir)
             );
         }
 

--- a/src/Delivery/Console/WarmUpCacheCommand.php
+++ b/src/Delivery/Console/WarmUpCacheCommand.php
@@ -46,12 +46,12 @@ class WarmUpCacheCommand extends Command
 
         if (!$fs->exists($cacheDir)) {
             throw new \InvalidArgumentException(
-                sprintf("Cache directory '<info>%s</info>' does not exist.", $cacheDir)
+                sprintf("Cache directory '%s' does not exist.", $cacheDir)
             );
         }
         if (!is_writable($cacheDir)) {
             throw new \InvalidArgumentException(
-                sprintf("Cache directory '<info>%s</info>' can not be written to.", $cacheDir)
+                sprintf("Cache directory '%s' can not be written to.", $cacheDir)
             );
         }
 


### PR DESCRIPTION
The <info> tags can't be used when it's part of the exception message. Actually we don't even need esceptions here, we can just write our error message and terminate.

Fixes #129