### PR TITLE
Fixes a missing parameter in DynamicEntryTest.

### DIFF
--- a/tests/Unit/Delivery/DynamicEntryTest.php
+++ b/tests/Unit/Delivery/DynamicEntryTest.php
@@ -216,7 +216,7 @@ class DynamicEntryTest extends \PHPUnit_Framework_TestCase
                     return $crookshanksEntry;
                 }
 
-                return new NotFoundException;
+                return new NotFoundException(new ClientException('abc', new Request('GET', '')));
             });
 
         $this->assertSame($crookshanksEntry, $garfieldEntry->getFriend());


### PR DESCRIPTION
This code isn't called when the test succeeds but let's do it right.