### PR TITLE
Adds functionality for storing info from previous response headers

### DIFF
--- a/src/Delivery/Client.php
+++ b/src/Delivery/Client.php
@@ -167,6 +167,8 @@ class Client extends BaseClient
     public function getContentType($id)
     {
         if ($this->instanceCache->hasContentType($id)) {
+            $this->nullifyResponseInfo();
+
             return $this->instanceCache->getContentType($id);
         }
 
@@ -239,6 +241,8 @@ class Client extends BaseClient
     public function getSpace()
     {
         if ($this->instanceCache->hasSpace()) {
+            $this->nullifyResponseInfo();
+
             return $this->instanceCache->getSpace();
         }
 

--- a/src/Delivery/ResourceBuilder.php
+++ b/src/Delivery/ResourceBuilder.php
@@ -267,6 +267,8 @@ class ResourceBuilder
     private function buildContentType(array $data)
     {
         if ($this->instanceCache->hasContentType($data['sys']['id'])) {
+            $this->client->nullifyResponseInfo();
+
             return $this->instanceCache->getContentType($data['sys']['id']);
         }
 
@@ -500,6 +502,8 @@ class ResourceBuilder
         }
 
         if ($this->instanceCache->hasSpace()) {
+            $this->client->nullifyResponseInfo();
+
             return $this->instanceCache->getSpace();
         }
 

--- a/src/Delivery/ResponseInfo.php
+++ b/src/Delivery/ResponseInfo.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * This file is part of the contentful.php package.
+ *
+ * @copyright 2015-2017 Contentful GmbH
+ * @license   MIT
+ */
+
+namespace Contentful\Delivery;
+
+use Contentful\ResponseInfo as BaseResponseInfo;
+use GuzzleHttp\Psr7\Response;
+
+/**
+ * {@inheritdoc}
+ */
+class ResponseInfo extends BaseResponseInfo
+{
+    /**
+     * It can be either "HIT" or "MISS".
+     *
+     * @var string
+     */
+    private $cache;
+
+    /**
+     * @var int
+     */
+    private $cacheHits;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(Response $response)
+    {
+        parent::__construct($response);
+
+        $this->cache = $response->getHeaderLine('X-Cache');
+        $this->cacheHits = (int) $response->getHeaderLine('X-Cache-Hits');
+    }
+
+    /**
+     * @return string
+     */
+    public function getCache()
+    {
+        return $this->cache;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCacheHits()
+    {
+        return $this->cacheHits;
+    }
+}

--- a/src/Preview/ResponseInfo.php
+++ b/src/Preview/ResponseInfo.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This file is part of the contentful.php package.
+ *
+ * @copyright 2015-2017 Contentful GmbH
+ * @license   MIT
+ */
+
+namespace Contentful\Preview;
+
+use Contentful\ResponseInfo as BaseResponseInfo;
+
+/**
+ * {@inheritdoc}
+ */
+class ResponseInfo extends BaseResponseInfo
+{
+}

--- a/src/ResponseInfo.php
+++ b/src/ResponseInfo.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * This file is part of the contentful.php package.
+ *
+ * @copyright 2015-2017 Contentful GmbH
+ * @license   MIT
+ */
+
+namespace Contentful;
+
+use GuzzleHttp\Psr7\Response;
+
+/**
+ * ResponseInfo class.
+ *
+ * This class receives a Response object generated from a request to Contentful,
+ * and it stores useful data that is described in the response headers.
+ */
+abstract class ResponseInfo
+{
+    /**
+     * @var string
+     */
+    private $requestId;
+
+    /**
+     * Constructor.
+     *
+     * @param Response $response
+     */
+    public function __construct(Response $response)
+    {
+        $this->requestId = $response->getHeaderLine('X-Contentful-Request-Id');
+    }
+
+    /**
+     * @return string
+     */
+    public function getRequestId()
+    {
+        return $this->requestId;
+    }
+}

--- a/tests/E2E/ResponseInfoTest.php
+++ b/tests/E2E/ResponseInfoTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * This file is part of the contentful.php package.
+ *
+ * @copyright 2015-2017 Contentful GmbH
+ * @license   MIT
+ */
+
+namespace Contentful\Tests\E2E;
+
+use Contentful\Delivery\Client;
+use Contentful\Delivery\ResponseInfo as DeliveryResponseInfo;
+use Contentful\Preview\ResponseInfo as PreviewResponseInfo;
+
+class ResponseInfoTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @vcr e2e_response_info_delivery.json
+     */
+    public function testSavedResponseInfo()
+    {
+        $client = new Client('b4c0n73n7fu1', 'cfexampleapi');
+
+        $client->getSpace();
+
+        $responseInfo = $client->getLastResponseInfo();
+
+        $this->assertInstanceOf(DeliveryResponseInfo::class, $responseInfo);
+        $this->assertRegexp('/([a-z0-9]{32})/', $responseInfo->getRequestId());
+
+        $this->assertContains($responseInfo->getCache(), ['HIT', 'MISS']);
+        $this->assertGreaterThanOrEqual(0, $responseInfo->getCacheHits());
+    }
+
+    /**
+     * @vcr e2e_response_info_preview.json
+     */
+    public function testPreviewResponseInfo()
+    {
+        $client = new Client('81c469d7241ca02349388602dfc14107157063a6901c378a56e1835d688970bf', '88dyiqcr7go8', true);
+
+        $client->getSpace();
+
+        $responseInfo = $client->getLastResponseInfo();
+
+        $this->assertInstanceOf(PreviewResponseInfo::class, $responseInfo);
+        $this->assertRegexp('/([a-z0-9]{32})/', $responseInfo->getRequestId());
+    }
+}

--- a/tests/recordings/e2e_response_info_delivery.json
+++ b/tests/recordings/e2e_response_info_delivery.json
@@ -1,0 +1,46 @@
+[{
+    "request": {
+        "method": "GET",
+        "url": "https:\/\/cdn.contentful.com\/spaces\/cfexampleapi\/",
+        "headers": {
+            "Host": "cdn.contentful.com",
+            "User-Agent": "GuzzleHttp\/6.2.1 curl\/7.51.0 PHP\/7.1.6",
+            "X-Contentful-User-Agent": "sdk contentful.php\/2.1.0-dev; platform PHP\/7.1.6; os macOS;",
+            "Accept": "application\/vnd.contentful.delivery.v1+json",
+            "Accept-Encoding": "gzip",
+            "Authorization": "Bearer b4c0n73n7fu1"
+        }
+    },
+    "response": {
+        "status": {
+            "http_version": "1.1",
+            "code": "200",
+            "message": "OK"
+        },
+        "headers": {
+            "Access-Control-Allow-Headers": "Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent",
+            "Access-Control-Allow-Methods": "GET,HEAD,OPTIONS",
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Expose-Headers": "Etag",
+            "Access-Control-Max-Age": "86400",
+            "Cache-Control": "max-age=0",
+            "Content-Type": "application\/vnd.contentful.delivery.v1+json",
+            "ETag": "\"17f6b9f68596176aed46fa020bf235af\"",
+            "Server": "Contentful",
+            "X-Content-Type-Options": "nosniff",
+            "X-Contentful-Request-Id": "619faf018600aa22a357db0a4914a39f",
+            "Content-Length": "344",
+            "Accept-Ranges": "bytes",
+            "Date": "Fri, 07 Jul 2017 18:20:41 GMT",
+            "Via": "1.1 varnish",
+            "Age": "572",
+            "Connection": "keep-alive",
+            "X-Served-By": "cache-hhn1528-HHN",
+            "X-Cache": "HIT",
+            "X-Cache-Hits": "2",
+            "X-Timer": "S1499451641.066559,VS0,VE0",
+            "Vary": "Accept-Encoding"
+        },
+        "body": "{\n  \"sys\": {\n    \"type\": \"Space\",\n    \"id\": \"cfexampleapi\"\n  },\n  \"name\": \"Contentful Example API\",\n  \"locales\": [\n    {\n      \"code\": \"en-US\",\n      \"default\": true,\n      \"name\": \"English\",\n      \"fallbackCode\": null\n    },\n    {\n      \"code\": \"tlh\",\n      \"default\": false,\n      \"name\": \"Klingon\",\n      \"fallbackCode\": \"en-US\"\n    }\n  ]\n}\n"
+    }
+}]

--- a/tests/recordings/e2e_response_info_preview.json
+++ b/tests/recordings/e2e_response_info_preview.json
@@ -1,0 +1,40 @@
+[{
+    "request": {
+        "method": "GET",
+        "url": "https:\/\/preview.contentful.com\/spaces\/88dyiqcr7go8\/",
+        "headers": {
+            "Host": "preview.contentful.com",
+            "User-Agent": "GuzzleHttp\/6.2.1 curl\/7.51.0 PHP\/7.1.6",
+            "X-Contentful-User-Agent": "sdk contentful.php\/2.1.0-dev; platform PHP\/7.1.6; os macOS;",
+            "Accept": "application\/vnd.contentful.delivery.v1+json",
+            "Accept-Encoding": "gzip",
+            "Authorization": "Bearer 81c469d7241ca02349388602dfc14107157063a6901c378a56e1835d688970bf"
+        }
+    },
+    "response": {
+        "status": {
+            "http_version": "1.1",
+            "code": "200",
+            "message": "OK"
+        },
+        "headers": {
+            "Access-Control-Allow-Headers": "Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent",
+            "Access-Control-Allow-Methods": "GET,HEAD,OPTIONS",
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Expose-Headers": "Etag",
+            "Access-Control-Max-Age": "1728000",
+            "CF-Cache-Name": "content_delivery",
+            "CF-Organization-Id": "3ubGFD1MWA6VgVYbIwSBg8",
+            "CF-Space-Id": "88dyiqcr7go8",
+            "Content-Type": "application\/vnd.contentful.delivery.v1+json",
+            "Date": "Fri, 07 Jul 2017 18:20:41 GMT",
+            "ETag": "\"2c57cba8c83129c95bbb8579dced315d\"",
+            "Server": "Contentful",
+            "X-Content-Type-Options": "nosniff",
+            "X-Contentful-Request-Id": "0f6d4acad2c1489f699e249e82110ba0",
+            "Content-Length": "442",
+            "Connection": "keep-alive"
+        },
+        "body": "{\n  \"sys\": {\n    \"type\": \"Space\",\n    \"id\": \"88dyiqcr7go8\"\n  },\n  \"name\": \"PHP CDA\",\n  \"locales\": [\n    {\n      \"code\": \"en-US\",\n      \"default\": true,\n      \"name\": \"U.S. English\",\n      \"fallbackCode\": null\n    },\n    {\n      \"code\": \"it\",\n      \"default\": false,\n      \"name\": \"Italian\",\n      \"fallbackCode\": \"en-US\"\n    },\n    {\n      \"code\": \"es\",\n      \"default\": false,\n      \"name\": \"Spanish\",\n      \"fallbackCode\": \"it\"\n    }\n  ]\n}\n"
+    }
+}]


### PR DESCRIPTION
It can be used to access certain headers, such as those for rate limits (in the CMA), cache info (in the CDA) and Contentful's generated request ID.

Use would be as simple as
``` php
$entry = $client->getEntry($entryId);

$responseInfo = $client->getLastResponseInfo();
$responseInfo->getRequestId();
$responseInfo->getCacheHits();
```

This info could have been previously retrieved by manual creating a logger and passing it to the Client, then looking for the correct entry in the logs, and finally manually parsing the headers.

It is designed in a way that makes it easy to extend for the CMA (we just need to create `Contentful\Management\ResponseInfo`), and it deals with cached objects by nullifying the result. I could write some tests to for cover this situation, but first I wanted an opinion on the overall thing 🙂 