### PR TITLE
Removes soap from the list of library hooks that are used by php-vcr.

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -26,6 +26,7 @@ function clean_headers_array(\VCR\Request $request)
 \VCR\VCR::configure()
     ->setMode('once')
     ->setStorage('json')
+    ->enableLibraryHooks(['stream_wrapper', 'curl'])
     ->setCassettePath('tests/recordings')
     ->addRequestMatcher('custom_headers', function (\VCR\Request $first, \VCR\Request $second) {
         $first = clean_headers_array($first);


### PR DESCRIPTION
This should enable running the test suite without having the soap extension installed.