### PR TITLE
Configures the SDK for testing in API coverage environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * The third parameter `$options` of the `Client::request()` method now accepts an optional value with key `baseUri`. This is in preparation for the CMA SDK.
 * Revamped the [reference documentation](https://contentful.github.io/contentful.php/api/) to be based on Sami and to include previous versions of the SDK.
 * `LocalUploadFile` now handles asset files which have been uploaded to `upload.contentful.com` but have yet to be processed. This fixes a possible edge case, and it's also done in preparation for the upcoming CMA SDK.
+* `Contentful\Client` now includes a `getLogger` method, for easy access to the logger currently in use.
 
 ### Fixed
 * Slight fixes to error messages in exceptions thrown in the `ResourceBuilder`.

--- a/phpunit-api-coverage.xml
+++ b/phpunit-api-coverage.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-        bootstrap="tests/bootstrap.php"
-        checkForUnintentionallyCoveredCode="true">
+<phpunit bootstrap="tests/bootstrap-api-coverage.php">
     <testsuites>
         <testsuite name="e2e">
             <directory>tests/E2E</directory>
@@ -13,4 +11,8 @@
             <directory suffix=".php">src</directory>
         </whitelist>
     </filter>
+
+    <php>
+        <env name="CONTENTFUL_CDA_SDK_TESTING_URL" value="http://localhost:5000/" />
+    </php>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-        bootstrap="tests/bootstrap.php">
+<phpunit bootstrap="tests/bootstrap.php">
     <testsuites>
         <testsuite name="unit">
             <directory>tests/Unit</directory>

--- a/src/Client.php
+++ b/src/Client.php
@@ -237,6 +237,14 @@ abstract class Client
     }
 
     /**
+     * @return LoggerInterface
+     */
+    public function getLogger()
+    {
+        return $this->logger;
+    }
+
+    /**
      * The name of the library to be used in the User-Agent header.
      *
      * @return string

--- a/tests/E2E/AssetBasicTest.php
+++ b/tests/E2E/AssetBasicTest.php
@@ -7,31 +7,23 @@
 namespace Contentful\Tests\E2E;
 
 use Contentful\File\ImageFile;
-use Contentful\Delivery\Client;
 use Contentful\Delivery\Query;
 use Contentful\ResourceArray;
 use Contentful\Delivery\Asset;
+use Contentful\Tests\Delivery\End2EndTestCase;
 
-class AssetBasicTest extends \PHPUnit_Framework_TestCase
+class AssetBasicTest extends End2EndTestCase
 {
-    /**
-     * @var Client
-     */
-    private $client;
-
-    public function setUp()
-    {
-        $this->client = new Client('b4c0n73n7fu1', 'cfexampleapi');
-    }
-
     /**
      * @vcr e2e_asset_get_all_locale_all.json
      */
     public function testGetAll()
     {
+        $client = $this->getClient('cfexampleapi');
+
         $query = (new Query())
             ->setLocale('*');
-        $assets = $this->client->getAssets($query);
+        $assets = $client->getAssets($query);
 
         $this->assertInstanceOf(ResourceArray::class, $assets);
     }
@@ -41,7 +33,9 @@ class AssetBasicTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetAllSingleLocale()
     {
-        $assets = $this->client->getAssets();
+        $client = $this->getClient('cfexampleapi');
+
+        $assets = $client->getAssets();
 
         $this->assertInstanceOf(ResourceArray::class, $assets);
     }
@@ -51,7 +45,9 @@ class AssetBasicTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetOne()
     {
-        $asset = $this->client->getAsset('nyancat', '*');
+        $client = $this->getClient('cfexampleapi');
+
+        $asset = $client->getAsset('nyancat', '*');
 
         $this->assertInstanceOf(Asset::class, $asset);
         $this->assertEquals('nyancat', $asset->getId());
@@ -63,7 +59,9 @@ class AssetBasicTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetOneSingleLocale()
     {
-        $asset = $this->client->getAsset('nyancat');
+        $client = $this->getClient('cfexampleapi');
+
+        $asset = $client->getAsset('nyancat');
 
         $this->assertInstanceOf(Asset::class, $asset);
         $this->assertEquals('nyancat', $asset->getId());

--- a/tests/E2E/AssetLocaleTest.php
+++ b/tests/E2E/AssetLocaleTest.php
@@ -7,32 +7,24 @@
 namespace Contentful\Tests\E2E;
 
 use Contentful\File\File;
-use Contentful\Delivery\Client;
 use Contentful\Delivery\Query;
+use Contentful\Tests\Delivery\End2EndTestCase;
 
-class AssetLocaleTest extends \PHPUnit_Framework_TestCase
+class AssetLocaleTest extends End2EndTestCase
 {
-    /**
-     * @var Client
-     */
-    private $client;
-
-    public function setUp()
-    {
-        $this->client = new Client('668efbfd9e398181166dec5df5a500aded96dbca2916646a3c7ec37082a7b756', '88dyiqcr7go8');
-    }
-
     /**
      * @vcr e2e_asset_included_locale.json
      */
     public function testIncludedAssetLocale()
     {
+        $client = $this->getClient('88dyiqcr7go8');
+
         $query = (new Query())
             ->setInclude(1)
             ->where('sys.id', 'Kpwt1njxgAm04oQYyUScm')
             ->setLocale('es');
 
-        $entry = $this->client->getEntries($query)[0];
+        $entry = $client->getEntries($query)[0];
         // This is to make sure that the retrieved asset has the locale code correctly initialized
         $this->assertEquals('Ben Chang', $entry->getName());
         $this->assertEquals('Señor', $entry->getJobTitle());

--- a/tests/E2E/CacheTest.php
+++ b/tests/E2E/CacheTest.php
@@ -8,36 +8,42 @@ namespace Contentful\Tests\E2E;
 
 use Contentful\Delivery\Cache\CacheClearer;
 use Contentful\Delivery\Cache\CacheWarmer;
-use Contentful\Delivery\Client;
+use Contentful\Tests\Delivery\End2EndTestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
-class CacheTest extends \PHPUnit_Framework_TestCase
+class CacheTest extends End2EndTestCase
 {
+    private function clearCacheDir()
+    {
+        (new Filesystem())
+            ->remove(self::$cacheDir);
+    }
+
     /**
      * @vcr e2e_cache_warmup_clear.json
      */
     public function testCacheWarmupClear()
     {
-        $cacheDir = __DIR__ . '/../../build/cache';
-        $spaceId = 'cfexampleapi';
-        $fs = new Filesystem;
+        $this->clearCacheDir();
 
-        // To be safe, we start with an empty state
-        $fs->remove($cacheDir);
+        $fs = new Filesystem();
 
-        $client = new Client('b4c0n73n7fu1', $spaceId);
+        $client = $this->getClient('cfexampleapi');
+
         $warmer = new CacheWarmer($client);
-        $clearer = new CacheClearer($spaceId);
+        $clearer = new CacheClearer('cfexampleapi');
 
-        $warmer->warmUp($cacheDir);
-        $this->assertTrue($fs->exists($cacheDir . '/' . $spaceId));
-        $this->assertTrue($fs->exists($cacheDir . '/' . $spaceId . '/space.json'));
+        $warmer->warmUp(self::$cacheDir);
+        $this->assertTrue($fs->exists(self::$cacheDir . '/cfexampleapi'));
+        $this->assertTrue($fs->exists(self::$cacheDir . '/cfexampleapi/space.json'));
 
-        $rawSpace = json_decode(file_get_contents($cacheDir . '/' . $spaceId . '/space.json'), true);
-        $this->assertEquals($spaceId, $rawSpace['sys']['id']);
+        $rawSpace = json_decode(file_get_contents(self::$cacheDir . '/cfexampleapi/space.json'), true);
+        $this->assertEquals('cfexampleapi', $rawSpace['sys']['id']);
 
-        $clearer->clear($cacheDir);
-        $this->assertFalse($fs->exists($cacheDir . '/' . $spaceId));
+        $clearer->clear(self::$cacheDir);
+        $this->assertFalse($fs->exists(self::$cacheDir . '/cfexampleapi'));
+
+        $this->clearCacheDir();
     }
 
     /**
@@ -45,16 +51,14 @@ class CacheTest extends \PHPUnit_Framework_TestCase
      */
     public function testApiWorksWithEmptyCache()
     {
-        $cacheDir = __DIR__ . '/../../build/cache';
-        $spaceId = 'cfexampleapi';
-        $fs = new Filesystem;
+        $this->clearCacheDir();
 
-        // Make extra sure there's nothing cached
-        $fs->remove($cacheDir);
+        $client = $this->getClient('cfexampleapi_cache', true);
 
-        $client = new Client('b4c0n73n7fu1', $spaceId, false, null, ['cacheDir' => $cacheDir]);
-        $this->assertEquals($spaceId, $client->getSpace()->getId());
+        $this->assertEquals('cfexampleapi', $client->getSpace()->getId());
         $this->assertEquals('cat', $client->getContentType('cat')->getId());
+
+        $this->clearCacheDir();
     }
 
     /**
@@ -62,22 +66,18 @@ class CacheTest extends \PHPUnit_Framework_TestCase
      */
     public function testAccessCachedContent()
     {
-        $cacheDir = __DIR__ . '/../../build/cache';
-        $spaceId = 'cfexampleapi';
-        $fs = new Filesystem;
+        $this->clearCacheDir();
 
-        // To be safe, we start with an empty state
-        $fs->remove($cacheDir);
+        $client = $this->getClient('cfexampleapi');
 
-        $client = new Client('b4c0n73n7fu1', $spaceId);
         $warmer = new CacheWarmer($client);
-        $warmer->warmUp($cacheDir);
+        $warmer->warmUp(self::$cacheDir);
 
-        $client = new Client('b4c0n73n7fu1', $spaceId, false, null, ['cacheDir' => $cacheDir]);
-        $this->assertEquals($spaceId, $client->getSpace()->getId());
+        $client = $this->getClient('cfexampleapi_cache', true);
+
+        $this->assertEquals('cfexampleapi', $client->getSpace()->getId());
         $this->assertEquals('cat', $client->getContentType('cat')->getId());
 
-        // Don't forget to clean up
-        $fs->remove($cacheDir);
+        $this->clearCacheDir();
     }
 }

--- a/tests/E2E/ContentTypeBasicTest.php
+++ b/tests/E2E/ContentTypeBasicTest.php
@@ -6,28 +6,20 @@
 
 namespace Contentful\Tests\E2E;
 
-use Contentful\Delivery\Client;
 use Contentful\ResourceArray;
 use Contentful\Delivery\ContentType;
+use Contentful\Tests\Delivery\End2EndTestCase;
 
-class ContentTypeBasicTest extends \PHPUnit_Framework_TestCase
+class ContentTypeBasicTest extends End2EndTestCase
 {
-    /**
-     * @var Client
-     */
-    private $client;
-
-    public function setUp()
-    {
-        $this->client = new Client('b4c0n73n7fu1', 'cfexampleapi');
-    }
-
     /**
      * @vcr e2e_content_type_get_all.json
      */
     public function testGetAll()
     {
-        $contentTypes = $this->client->getContentTypes();
+        $client = $this->getClient('cfexampleapi');
+
+        $contentTypes = $client->getContentTypes();
 
         $this->assertInstanceOf(ResourceArray::class, $contentTypes);
     }
@@ -37,7 +29,9 @@ class ContentTypeBasicTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetOne()
     {
-        $contentType = $this->client->getContentType('cat');
+        $client = $this->getClient('cfexampleapi');
+
+        $contentType = $client->getContentType('cat');
 
         $this->assertInstanceOf(ContentType::class, $contentType);
         $this->assertEquals('cat', $contentType->getId());

--- a/tests/E2E/EntryLocaleTest.php
+++ b/tests/E2E/EntryLocaleTest.php
@@ -6,31 +6,23 @@
 
 namespace Contentful\Tests\E2E;
 
-use Contentful\Delivery\Client;
 use Contentful\Delivery\Query;
 use Contentful\ResourceArray;
+use Contentful\Tests\Delivery\End2EndTestCase;
 
-class EntryLocaleTest extends \PHPUnit_Framework_TestCase
+class EntryLocaleTest extends End2EndTestCase
 {
-    /**
-     * @var Client
-     */
-    private $client;
-
-    public function setUp()
-    {
-        $this->client = new Client('b4c0n73n7fu1', 'cfexampleapi');
-    }
-
     /**
      * @vcr e2e_entry_locale_get_all.json
      */
     public function testGetAll()
     {
+        $client = $this->getClient('cfexampleapi');
+
         $query = (new Query)
             ->setContentType('cat')
             ->setLocale('*');
-        $entries = $this->client->getEntries($query);
+        $entries = $client->getEntries($query);
 
         $this->assertInstanceOf(ResourceArray::class, $entries);
         $this->assertEquals('Nyan Cat', $entries[0]->getName());
@@ -41,10 +33,12 @@ class EntryLocaleTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetEnUs()
     {
+        $client = $this->getClient('cfexampleapi');
+
         $query = (new Query)
             ->setContentType('cat')
             ->setLocale('en-US');
-        $entries = $this->client->getEntries($query);
+        $entries = $client->getEntries($query);
 
         $this->assertInstanceOf(ResourceArray::class, $entries);
         $this->assertEquals('Nyan Cat', $entries[0]->getName());
@@ -55,10 +49,12 @@ class EntryLocaleTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetTlh()
     {
+        $client = $this->getClient('cfexampleapi');
+
         $query = (new Query)
             ->setContentType('cat')
             ->setLocale('tlh');
-        $entries = $this->client->getEntries($query);
+        $entries = $client->getEntries($query);
 
         $this->assertInstanceOf(ResourceArray::class, $entries);
         $this->assertEquals('Nyan vIghro\'', $entries[0]->getName());
@@ -69,7 +65,7 @@ class EntryLocaleTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetLocaleFromClient()
     {
-        $client = new Client('b4c0n73n7fu1', 'cfexampleapi', false, 'tlh');
+        $client = $this->getClient('cfexampleapi_tlh');
 
         $query = (new Query)
             ->setContentType('cat');
@@ -85,7 +81,7 @@ class EntryLocaleTest extends \PHPUnit_Framework_TestCase
      */
     public function testLocaleUsedWithLazyLoading()
     {
-        $client = new Client('b4c0n73n7fu1', 'cfexampleapi');
+        $client = $this->getClient('cfexampleapi');
 
         $happycat = $client->getEntry('happycat', 'tlh');
         $nyancat = $happycat->getBestFriend();

--- a/tests/E2E/EntrySearchTest.php
+++ b/tests/E2E/EntrySearchTest.php
@@ -7,30 +7,22 @@
 namespace Contentful\Tests\E2E;
 
 use Contentful\Delivery\Query;
-use Contentful\Delivery\Client;
 use Contentful\ResourceArray;
+use Contentful\Tests\Delivery\End2EndTestCase;
 
-class EntrySearchTest extends \PHPUnit_Framework_TestCase
+class EntrySearchTest extends End2EndTestCase
 {
-    /**
-     * @var Client
-     */
-    private $client;
-
-    public function setUp()
-    {
-        $this->client = new Client('b4c0n73n7fu1', 'cfexampleapi');
-    }
-
     /**
      * @vcr e2e_entry_search_by_content_type.json
      */
     public function testSearchByContentType()
     {
+        $client = $this->getClient('cfexampleapi');
+
         $query = (new Query())
             ->setContentType('cat');
 
-        $entries = $this->client->getEntries($query);
+        $entries = $client->getEntries($query);
 
         $this->assertInstanceOf(ResourceArray::class, $entries);
     }
@@ -40,10 +32,12 @@ class EntrySearchTest extends \PHPUnit_Framework_TestCase
      */
     public function testSearchEquality()
     {
+        $client = $this->getClient('cfexampleapi');
+
         $query = (new Query())
             ->where('sys.id', 'nyancat');
 
-        $entries = $this->client->getEntries($query);
+        $entries = $client->getEntries($query);
 
         $this->assertInstanceOf(ResourceArray::class, $entries);
         $this->assertCount(1, $entries);
@@ -54,10 +48,12 @@ class EntrySearchTest extends \PHPUnit_Framework_TestCase
      */
     public function testSearchInequality()
     {
+        $client = $this->getClient('cfexampleapi');
+
         $query = (new Query())
             ->where('sys.id', 'nyancat', 'ne');
 
-        $entries = $this->client->getEntries($query);
+        $entries = $client->getEntries($query);
 
         $this->assertInstanceOf(ResourceArray::class, $entries);
         $this->assertCount(9, $entries);
@@ -68,11 +64,13 @@ class EntrySearchTest extends \PHPUnit_Framework_TestCase
      */
     public function testSearchArrayEquality()
     {
+        $client = $this->getClient('cfexampleapi');
+
         $query = (new Query())
             ->setContentType('cat')
             ->where('fields.likes', 'lasagna');
 
-        $entries = $this->client->getEntries($query);
+        $entries = $client->getEntries($query);
 
         $this->assertInstanceOf(ResourceArray::class, $entries);
     }
@@ -82,10 +80,12 @@ class EntrySearchTest extends \PHPUnit_Framework_TestCase
      */
     public function testSearchInclusion()
     {
+        $client = $this->getClient('cfexampleapi');
+
         $query = (new Query())
             ->where('sys.id', 'finn,jake', 'in');
 
-        $entries = $this->client->getEntries($query);
+        $entries = $client->getEntries($query);
 
         $this->assertInstanceOf(ResourceArray::class, $entries);
         $this->assertCount(2, $entries);
@@ -98,10 +98,12 @@ class EntrySearchTest extends \PHPUnit_Framework_TestCase
      */
     public function testSearchRange()
     {
+        $client = $this->getClient('cfexampleapi');
+
         $query = (new Query())
             ->where('sys.updatedAt', new \DateTimeImmutable('2013-01-01T00:00:00Z'), 'lte');
 
-        $entries = $this->client->getEntries($query);
+        $entries = $client->getEntries($query);
 
         $this->assertInstanceOf(ResourceArray::class, $entries);
     }
@@ -111,10 +113,12 @@ class EntrySearchTest extends \PHPUnit_Framework_TestCase
      */
     public function testSearchFullText()
     {
+        $client = $this->getClient('cfexampleapi');
+
         $query = (new Query())
             ->where('query', 'bacon');
 
-        $entries = $this->client->getEntries($query);
+        $entries = $client->getEntries($query);
 
         $this->assertInstanceOf(ResourceArray::class, $entries);
     }
@@ -124,11 +128,13 @@ class EntrySearchTest extends \PHPUnit_Framework_TestCase
      */
     public function testSearchFullTextOnField()
     {
+        $client = $this->getClient('cfexampleapi');
+
         $query = (new Query())
             ->setContentType('dog')
             ->where('fields.description', 'bacon pancakes', 'match');
 
-        $entries = $this->client->getEntries($query);
+        $entries = $client->getEntries($query);
 
         $this->assertInstanceOf(ResourceArray::class, $entries);
     }

--- a/tests/E2E/EntrySelectTest.php
+++ b/tests/E2E/EntrySelectTest.php
@@ -6,33 +6,25 @@
 
 namespace Contentful\Tests\E2E;
 
-use Contentful\Delivery\Client;
 use Contentful\Delivery\Query;
 use Contentful\ResourceArray;
+use Contentful\Tests\Delivery\End2EndTestCase;
 
-class EntrySelectTest extends \PHPUnit_Framework_TestCase
+class EntrySelectTest extends End2EndTestCase
 {
-    /**
-     * @var Client
-     */
-    private $client;
-
-    public function setUp()
-    {
-        $this->client = new Client('b4c0n73n7fu1', 'cfexampleapi');
-    }
-
     /**
      * @vcr e2e_entry_select_metadata.json
      */
     public function testSelectOnlyMetadata()
     {
+        $client = $this->getClient('cfexampleapi');
+
         $query = (new Query)
             ->setContentType('cat')
             ->select(['sys'])
             ->where('sys.id', 'nyancat')
             ->setLimit(1);
-        $entries = $this->client->getEntries($query);
+        $entries = $client->getEntries($query);
 
         $this->assertInstanceOf(ResourceArray::class, $entries);
         $this->assertNull($entries[0]->getName());
@@ -44,12 +36,14 @@ class EntrySelectTest extends \PHPUnit_Framework_TestCase
      */
     public function testSelectOnlyOneField()
     {
+        $client = $this->getClient('cfexampleapi');
+
         $query = (new Query)
             ->setContentType('cat')
             ->select(['fields.name'])
             ->where('sys.id', 'nyancat')
             ->setLimit(1);
-        $entries = $this->client->getEntries($query);
+        $entries = $client->getEntries($query);
 
         $this->assertInstanceOf(ResourceArray::class, $entries);
         $this->assertEquals('Nyan Cat', $entries[0]->getName());

--- a/tests/E2E/ErrorTest.php
+++ b/tests/E2E/ErrorTest.php
@@ -6,12 +6,11 @@
 
 namespace Contentful\Tests\E2E;
 
-use Contentful\Delivery\Client;
 use Contentful\Delivery\Query;
-
 use Contentful\Exception\RateLimitExceededException;
+use Contentful\Tests\Delivery\End2EndTestCase;
 
-class ErrorTest extends \PHPUnit_Framework_TestCase
+class ErrorTest extends End2EndTestCase
 {
     /**
      * @expectedException \Contentful\Exception\NotFoundException
@@ -19,7 +18,7 @@ class ErrorTest extends \PHPUnit_Framework_TestCase
      */
     public function testResourceNotFound()
     {
-        $client = new Client('b4c0n73n7fu1', 'cfexampleapi');
+        $client = $this->getClient('cfexampleapi');
 
         $client->getEntry('not-existing');
     }
@@ -30,7 +29,8 @@ class ErrorTest extends \PHPUnit_Framework_TestCase
      */
     public function testAccessTokenInvalid()
     {
-        $client = new Client('e5e8d4c5c122cf28fc1af3ff77d28bef78a3952957f15067bbc29f2f0dde0b50', 'cfexampleapi');
+        $client = $this->getClient('cfexampleapi_invalid');
+
         $client->getEntries();
     }
 
@@ -40,7 +40,8 @@ class ErrorTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidQuery()
     {
-        $client = new Client('b4c0n73n7fu1', 'cfexampleapi');
+        $client = $this->getClient('cfexampleapi');
+
         $query = (new Query())
             ->where('name', 0);
 
@@ -48,12 +49,14 @@ class ErrorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @requires API no-coverage-proxy
      * @expectedException \Contentful\Exception\RateLimitExceededException
      * @vcr e2e_error_rate_limit.json
      */
     public function testRateLimitExceeded()
     {
-        $client = new Client('8740056d546471e0640d189615470cc12ce2d3188332352ecfb53edac59c4963', 'bc32cj3kyfet', true);
+        $client = $this->getClient('bc32cj3kyfet_preview');
+
         $query = new Query();
 
         try {

--- a/tests/E2E/GzipEncodingTest.php
+++ b/tests/E2E/GzipEncodingTest.php
@@ -6,21 +6,19 @@
 
 namespace Contentful\Tests\E2E;
 
-use Contentful\Delivery\Client;
-use Contentful\Log\ArrayLogger;
 use Contentful\Delivery\Query;
+use Contentful\Tests\Delivery\End2EndTestCase;
 
-class GzipEncodingTest extends \PHPUnit_Framework_TestCase
+class GzipEncodingTest extends End2EndTestCase
 {
     /**
+     * @requires API no-coverage-proxy
      * @vcr e2e_gzip_encoding.json
      */
     public function testContentEncodingHeader()
     {
-        $logger = new ArrayLogger;
-        $client = new Client('b4c0n73n7fu1', 'cfexampleapi', false, null, [
-            'logger' => $logger
-        ]);
+        $client = $this->getClient('cfexampleapi_logger');
+        $logger = $client->getLogger();
 
         $query = (new Query())
             ->setLocale('*');
@@ -30,7 +28,7 @@ class GzipEncodingTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('gzip', $logEntry->getRequest()->getHeaderLine('Accept-Encoding'));
 
-        // Need to check 'x-encoded-content-encoding' as curl is automatically decompressing the response
-        $this->assertEquals('gzip', $logEntry->getResponse()->getHeaderLine('x-encoded-content-encoding'));
+        // Need to check 'X-Encoded-Content-Encoding' as curl is automatically decompressing the response
+        $this->assertEquals('gzip', $logEntry->getResponse()->getHeaderLine('X-Encoded-Content-Encoding'));
     }
 }

--- a/tests/E2E/SpaceBasicTest.php
+++ b/tests/E2E/SpaceBasicTest.php
@@ -6,27 +6,19 @@
 
 namespace Contentful\Tests\E2E;
 
-use Contentful\Delivery\Client;
 use Contentful\Delivery\Space;
+use Contentful\Tests\Delivery\End2EndTestCase;
 
-class SpaceBasicTest extends \PHPUnit_Framework_TestCase
+class SpaceBasicTest extends End2EndTestCase
 {
-    /**
-     * @var Client
-     */
-    private $client;
-
-    public function setUp()
-    {
-        $this->client = new Client('b4c0n73n7fu1', 'cfexampleapi');
-    }
-
     /**
      * @vcr e2e_space_get.json
      */
     public function testGetSpace()
     {
-        $space = $this->client->getSpace();
+        $client = $this->getClient('cfexampleapi');
+
+        $space = $client->getSpace();
 
         $this->assertInstanceOf(Space::class, $space);
         $this->assertEquals('Contentful Example API', $space->getName());

--- a/tests/E2E/SyncTest.php
+++ b/tests/E2E/SyncTest.php
@@ -6,19 +6,20 @@
 
 namespace Contentful\Tests\E2E;
 
-use Contentful\Delivery\Client;
 use Contentful\Delivery\DynamicEntry;
 use Contentful\Delivery\Synchronization\Result;
+use Contentful\Tests\Delivery\End2EndTestCase;
 
-class SyncTest extends \PHPUnit_Framework_TestCase
+class SyncTest extends End2EndTestCase
 {
     /**
      * @vcr e2e_sync_basic.json
      */
     public function testBasicSync()
     {
-        $manager = (new Client('b4c0n73n7fu1', 'cfexampleapi'))
-            ->getSynchronizationManager();
+        $client = $this->getClient('cfexampleapi');
+
+        $manager = $client->getSynchronizationManager();
 
         $result = $manager->startSync();
 
@@ -36,11 +37,12 @@ class SyncTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @requires API no-coverage-proxy
      * @vcr e2e_sync_preview.json
      */
     public function testPreviewSync()
     {
-        $manager = (new Client('e5e8d4c5c122cf28fc1af3ff77d28bef78a3952957f15067bbc29f2f0dde0b50', 'cfexampleapi', true))
+        $manager = $this->getClient('cfexampleapi_preview')
             ->getSynchronizationManager();
 
         $result = $manager->startSync();
@@ -50,12 +52,13 @@ class SyncTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @requires API no-coverage-proxy
      * @vcr e2e_sync_preview_continue.json
      * @expectedException \RuntimeException
      */
     public function testPreviewSyncContinue()
     {
-        $manager = (new Client('e5e8d4c5c122cf28fc1af3ff77d28bef78a3952957f15067bbc29f2f0dde0b50', 'cfexampleapi', true))
+        $manager = $this->getClient('cfexampleapi_preview')
             ->getSynchronizationManager();
 
         $result = $manager->startSync();

--- a/tests/E2E/UnprocessedFileInPreviewTest.php
+++ b/tests/E2E/UnprocessedFileInPreviewTest.php
@@ -7,28 +7,21 @@
 namespace Contentful\Tests\E2E;
 
 use Contentful\Link;
-use Contentful\Delivery\Client;
 use Contentful\File\UploadFile;
 use Contentful\File\LocalUploadFile;
+use Contentful\Tests\Delivery\End2EndTestCase;
 
-class UnprocessedFileInPreviewTest extends \PHPUnit_Framework_TestCase
+class UnprocessedFileInPreviewTest extends End2EndTestCase
 {
     /**
-     * @var Client
-     */
-    private $client;
-
-    public function setUp()
-    {
-        $this->client = new Client('81c469d7241ca02349388602dfc14107157063a6901c378a56e1835d688970bf', '88dyiqcr7go8', true);
-    }
-
-    /**
+     * @requires API no-coverage-proxy
      * @vcr e2e_file_get_unprocessed_file.json
      */
     public function testGetUnprocessedFile()
     {
-        $asset = $this->client->getAsset('147y8r7Fx4YSEWYAQyggui');
+        $client = $this->getClient('88dyiqcr7go8_preview');
+
+        $asset = $client->getAsset('147y8r7Fx4YSEWYAQyggui');
 
         $file = $asset->getFile();
 
@@ -47,11 +40,14 @@ class UnprocessedFileInPreviewTest extends \PHPUnit_Framework_TestCase
      * using the Management API. This is irrelevant for the Delivery API, but it's good to rememember
      * when dealing with the CMA.
      *
+     * @requires API no-coverage-proxy
      * @vcr e2e_file_uploaded_from_unprocessed_file.json
      */
     public function testUploadedFromFileUnprocessed()
     {
-        $asset = $this->client->getAsset('lp8z7n381EmisqwMgmqW2');
+        $client = $this->getClient('88dyiqcr7go8_preview');
+
+        $asset = $client->getAsset('lp8z7n381EmisqwMgmqW2');
 
         $file = $asset->getFile();
 

--- a/tests/E2E/UriOverrideTest.php
+++ b/tests/E2E/UriOverrideTest.php
@@ -8,26 +8,20 @@ namespace Contentful\Tests\E2E;
 
 use Contentful\Delivery\Client;
 
-class UriOverrideTest extends \PHPUnit_Framework_TestCase
+use Contentful\Tests\Delivery\End2EndTestCase;
+
+class UriOverrideTest extends End2EndTestCase
 {
     /**
-     * @var Client
-     */
-    private $client;
-
-    public function setUp()
-    {
-        $this->client = new Client('e5e8d4c5c122cf28fc1af3ff77d28bef78a3952957f15067bbc29f2f0dde0b50', 'cfexampleapi', false, null, [
-            'uriOverride' => 'https://preview.contentful.com/'
-        ]);
-    }
-
-    /**
+     * @requires API no-coverage-proxy
      * @vcr e2e_uri_override.json
      */
     public function testBasicSync()
     {
-        $space = $this->client->getSpace();
+        $client = new Client('e5e8d4c5c122cf28fc1af3ff77d28bef78a3952957f15067bbc29f2f0dde0b50', 'cfexampleapi', false, null, [
+            'uriOverride' => 'https://preview.contentful.com/'
+        ]);
+        $space = $client->getSpace();
 
         $this->assertEquals('Contentful Example API', $space->getName());
     }

--- a/tests/End2EndTestCase.php
+++ b/tests/End2EndTestCase.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * @copyright 2015-2017 Contentful GmbH
+ * @license   MIT
+ */
+
+namespace Contentful\Tests\Delivery;
+
+use Contentful\Delivery\Client;
+use Contentful\Log\ArrayLogger;
+
+class End2EndTestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var string
+     */
+    protected static $cacheDir = '';
+
+    public static function setUpBeforeClass()
+    {
+        self::$cacheDir = __DIR__ . '/../build/cache';
+    }
+
+    /**
+     * @param string $key
+     *
+     * @return Client
+     */
+    protected function getClient($key)
+    {
+        $testingUrl = getenv('CONTENTFUL_CDA_SDK_TESTING_URL');
+        $options = $testingUrl
+            ? ['uriOverride' => $testingUrl]
+            : [];
+
+        switch ($key) {
+            case 'cfexampleapi':
+                return new Client('b4c0n73n7fu1', 'cfexampleapi', false, null, $options);
+            case 'cfexampleapi_preview':
+                return new Client('e5e8d4c5c122cf28fc1af3ff77d28bef78a3952957f15067bbc29f2f0dde0b50', 'cfexampleapi', true, null, $options);
+            case 'cfexampleapi_cache':
+                return new Client('b4c0n73n7fu1', 'cfexampleapi', false, null, array_merge($options, ['cacheDir' => self::$cacheDir]));
+            case 'cfexampleapi_logger':
+                return new Client('b4c0n73n7fu1', 'cfexampleapi', false, null, array_merge($options, ['logger' => new ArrayLogger()]));
+            case 'cfexampleapi_tlh':
+                return new Client('b4c0n73n7fu1', 'cfexampleapi', false, 'tlh', $options);
+            case 'cfexampleapi_invalid':
+                return new Client('e5e8d4c5c122cf28fc1af3ff77d28bef78a3952957f15067bbc29f2f0dde0b50', 'cfexampleapi', false, null, $options);
+            case '88dyiqcr7go8':
+                return new Client('668efbfd9e398181166dec5df5a500aded96dbca2916646a3c7ec37082a7b756', '88dyiqcr7go8', false, null, $options);
+            case '88dyiqcr7go8_preview':
+                return new Client('81c469d7241ca02349388602dfc14107157063a6901c378a56e1835d688970bf', '88dyiqcr7go8', true, null, $options);
+            case 'bc32cj3kyfet_preview':
+                return new Client('8740056d546471e0640d189615470cc12ce2d3188332352ecfb53edac59c4963', 'bc32cj3kyfet', true, null, $options);
+            default:
+                throw new \InvalidArgumentException('Argument $key is not a valid value');
+        }
+    }
+
+    protected function checkRequirements()
+    {
+        if (!getenv('CONTENTFUL_CDA_SDK_TESTING_URL')) {
+            return parent::checkRequirements();
+        }
+
+        $annotations = $this->getAnnotations();
+
+        foreach (['class', 'method'] as $depth) {
+            if (empty($annotations[$depth]['requires'])) {
+                continue;
+            }
+
+            $requires = array_flip($annotations[$depth]['requires']);
+
+            if (isset($requires['API no-coverage-proxy'])) {
+                return $this->markTestSkipped('This configuration blocks tests that should not be run when in the coverage proxy environment.');
+            }
+        }
+    }
+}

--- a/tests/bootstrap-api-coverage.php
+++ b/tests/bootstrap-api-coverage.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @copyright 2015-2016 Contentful GmbH
+ * @copyright 2015-2017 Contentful GmbH
  * @license   MIT
  */
 
 require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/End2EndTestCase.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,11 @@
 <?php
+/**
+ * @copyright 2015-2017 Contentful GmbH
+ * @license   MIT
+ */
 
 require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/End2EndTestCase.php';
 
 /**
  * @param \VCR\Request $request


### PR DESCRIPTION
It's mostly changes to the tests, except 2 things:
- `Contentful\Client` now has the method `getLogger` (which maybe could go in the changelog)
- `Contentful\Exception\ApiExeption` now uses `getHeaderLine` for accessing `X-Contentful-Request-Id`, which is safer as it returns an empty string if no header with that name is available.

The rest of the changes are in the `tests` directory, where basically I extracted all `Client` instantiations and moved them to the base `End2EndTestCase` class. As some of the tests involved cleaning up a cache directory, I simply moved these operations to the base `setUp` and `tearDown` methods.

Tests that are not suitable for running in a proxy environment are marked with the PHPUnit annotation `@requires Contentful`, and automatically skipped.