### PR TITLE
Removes static helpers in favor of simple functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/contentful/contentful.php/compare/2.1.0...HEAD)
 
+### Changed
+* `DateHelper::formatForJson()` is now deprecated and will be removed in version 3. Use `Contentful\format_date_for_json()` instead.
+* `JsonHelper::encode()` and `JsonHelper::decode()` are now deprecated and will be removed in version 3. Use `GuzzleHttp\json_encode()` and `GuzzleHttp\json_decode()` instead.
+
 ## [2.1.0](https://github.com/contentful/contentful.php/tree/2.1.0) (2017-07-14)
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "jakub-onderka/php-console-highlighter": "^0.3.2"
     },
     "autoload": {
+        "files": ["src/functions.php"],
         "psr-4": {
             "Contentful\\": "src/"
         }

--- a/src/Client.php
+++ b/src/Client.php
@@ -144,7 +144,7 @@ abstract class Client
             if ($response->getStatusCode() === 204) {
                 $result = null;
             } else {
-                $result = JsonHelper::decode($response->getBody());
+                $result = \GuzzleHttp\json_decode($response->getBody(), true);
             }
         } catch (\Exception $e) {
             $timer->stop();
@@ -174,7 +174,7 @@ abstract class Client
                 throw $e;
             }
 
-            $data = JsonHelper::decode($e->getResponse()->getBody());
+            $data = \GuzzleHttp\json_decode($e->getResponse()->getBody(), true);
             $errorId = $data['sys']['id'];
             $exceptionMap = $this->getExceptionMap();
 

--- a/src/DateHelper.php
+++ b/src/DateHelper.php
@@ -12,19 +12,16 @@ class DateHelper
      * Unfortunately PHP has no easy way to create a nice, ISO 8601 formatted date string with milliseconds and Z
      * as the time zone specifier. Thus this hack.
      *
-     * @param  \DateTimeImmutable $dt
+     * @param  \DateTimeImmutable $date
      *
      * @return string ISO 8601 formatted date
+     *
+     * @deprecated 2.2 Use Contentful\format_date_for_json($date) instead
+     *
+     * @see Contentful\format_date_for_json()
      */
-    public static function formatForJson(\DateTimeImmutable $dt)
+    public static function formatForJson(\DateTimeImmutable $date)
     {
-        $dt = $dt->setTimezone(new \DateTimeZone('Etc/UTC'));
-        $result = $dt->format('Y-m-d\TH:i:s') ;
-        $milliseconds =floor($dt->format('u')/1000);
-        if ($milliseconds > 0) {
-            $result .= '.' . str_pad($milliseconds, 3, '0', STR_PAD_LEFT);
-        }
-
-        return $result . 'Z';
+        return format_date_for_json($date);
     }
 }

--- a/src/Delivery/Client.php
+++ b/src/Delivery/Client.php
@@ -12,7 +12,6 @@ use Contentful\Delivery\Cache\NullCache;
 use Contentful\Delivery\Cache\InstanceCache;
 use Contentful\Delivery\Synchronization\Manager;
 use Contentful\Link;
-use Contentful\JsonHelper;
 
 /**
  * A Client is used to communicate the Contentful Delivery API.
@@ -300,7 +299,7 @@ class Client extends BaseClient
      */
     public function reviveJson($json)
     {
-        $data = JsonHelper::decode($json);
+        $data = \GuzzleHttp\json_decode($json, true);
 
         return $this->builder->buildObjectsFromRawData($data);
     }

--- a/src/Delivery/DynamicEntry.php
+++ b/src/Delivery/DynamicEntry.php
@@ -7,7 +7,6 @@
 namespace Contentful\Delivery;
 
 use Contentful\Exception\NotFoundException;
-use Contentful\DateHelper;
 use Contentful\Link;
 
 class DynamicEntry extends LocalizedResource implements EntryInterface
@@ -244,7 +243,7 @@ class DynamicEntry extends LocalizedResource implements EntryInterface
             case 'Object':
                 return $value;
             case 'Date':
-                return DateHelper::formatForJson($value);
+                return \Contentful\format_date_for_json($value);
             case 'Link':
                 return $value ? (object) [
                     'sys' => (object) [

--- a/src/Delivery/ResourceBuilder.php
+++ b/src/Delivery/ResourceBuilder.php
@@ -11,7 +11,6 @@ use Contentful\Delivery\Synchronization\DeletedAsset;
 use Contentful\Delivery\Synchronization\DeletedEntry;
 use Contentful\Delivery\Cache\InstanceCache;
 use Contentful\Delivery\Cache\CacheInterface;
-use Contentful\JsonHelper;
 use Contentful\Location;
 use Contentful\ResourceArray;
 use Contentful\Link;
@@ -272,7 +271,7 @@ class ResourceBuilder
 
         $cache = $this->filesystemCache->readContentType($data['sys']['id']);
         if ($cache !== null) {
-            $data = JsonHelper::decode($cache);
+            $data = \GuzzleHttp\json_decode($cache, true);
         }
 
         $sys = $this->buildSystemProperties($data['sys']);

--- a/src/Delivery/SystemProperties.php
+++ b/src/Delivery/SystemProperties.php
@@ -6,8 +6,6 @@
 
 namespace Contentful\Delivery;
 
-use Contentful\DateHelper;
-
 /**
  * A SystemProperties instance contains the metadata of a resource.
  *
@@ -202,13 +200,13 @@ class SystemProperties implements \JsonSerializable
             $obj->locale = $this->locale;
         }
         if ($this->createdAt !== null) {
-            $obj->createdAt = DateHelper::formatForJson($this->createdAt);
+            $obj->createdAt = \Contentful\format_date_for_json($this->createdAt);
         }
         if ($this->updatedAt !== null) {
-            $obj->updatedAt = DateHelper::formatForJson($this->updatedAt);
+            $obj->updatedAt = \Contentful\format_date_for_json($this->updatedAt);
         }
         if ($this->deletedAt !== null) {
-            $obj->deletedAt = DateHelper::formatForJson($this->deletedAt);
+            $obj->deletedAt = \Contentful\format_date_for_json($this->deletedAt);
         }
 
         return $obj;

--- a/src/Exception/ApiException.php
+++ b/src/Exception/ApiException.php
@@ -6,7 +6,6 @@
 
 namespace Contentful\Exception;
 
-use Contentful\JsonHelper;
 use GuzzleHttp\Exception\RequestException as GuzzleRequestException;
 use Psr\Http\Message\ResponseInterface;
 
@@ -66,11 +65,11 @@ abstract class ApiException extends \RuntimeException
         }
 
         try {
-            $result = JsonHelper::decode($response->getBody());
+            $result = \GuzzleHttp\json_decode($response->getBody(), true);
             if (isset($result['message'])) {
                 return $result['message'];
             }
-        } catch (\RuntimeException $e) {
+        } catch (\InvalidArgumentException $e) {
             return $previous->getMessage();
         }
 

--- a/src/JsonHelper.php
+++ b/src/JsonHelper.php
@@ -17,15 +17,18 @@ class JsonHelper
      * @return array
      *
      * @throws \RuntimeException On invalid JSON
+     *
+     * @deprecated 2.2 Use \GuzzleHttp\json_decode() instead
+     *
+     * @see \GuzzleHttp\json_decode()
      */
     public static function decode($json)
     {
-        $result = json_decode($json, true);
-        if (json_last_error() !== JSON_ERROR_NONE) {
+        try {
+            return \GuzzleHttp\json_decode($json, true);
+        } catch (\InvalidArgumentException $e) {
             throw new \RuntimeException(json_last_error_msg(), json_last_error());
         }
-
-        return $result;
     }
 
     /**
@@ -34,14 +37,17 @@ class JsonHelper
      * @return string
      *
      * @throws \RuntimeException When the encoding failed
+     *
+     * @deprecated 2.2 Use \GuzzleHttp\json_encode() instead
+     *
+     * @see \GuzzleHttp\json_encode()
      */
     public static function encode($value)
     {
-        $result = json_encode($value, JSON_UNESCAPED_UNICODE);
-        if (json_last_error() !== JSON_ERROR_NONE) {
+        try {
+            return \GuzzleHttp\json_encode($value, JSON_UNESCAPED_UNICODE);
+        } catch (\InvalidArgumentException $e) {
             throw new \RuntimeException(json_last_error_msg(), json_last_error());
         }
-
-        return $result;
     }
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @copyright 2015-2017 Contentful GmbH
+ * @license   MIT
+ */
+
+namespace Contentful;
+
+/**
+  * Unfortunately PHP has no easy way to create a nice, ISO 8601 formatted date string with milliseconds and Z
+  * as the time zone specifier. Thus this hack.
+  *
+  * @param \DateTimeImmutable $date
+  *
+  * @return string ISO 8601 formatted date
+  */
+ function format_date_for_json(\DateTimeImmutable $date)
+ {
+     $date = $date->setTimezone(new \DateTimeZone('Etc/UTC'));
+     $result = $date->format('Y-m-d\TH:i:s') ;
+     $milliseconds = floor($date->format('u')/1000);
+     if ($milliseconds > 0) {
+         $result .= '.' . str_pad($milliseconds, 3, '0', STR_PAD_LEFT);
+     }
+
+     return $result . 'Z';
+ }

--- a/tests/Integration/ReviveJsonTest.php
+++ b/tests/Integration/ReviveJsonTest.php
@@ -23,7 +23,7 @@ class ReviveJsonTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \RuntimeException
+     * @expectedException \InvalidArgumentException
      */
     public function testReviveJsonInvalid()
     {

--- a/tests/Unit/DateHelperTest.php
+++ b/tests/Unit/DateHelperTest.php
@@ -17,6 +17,7 @@ class DateHelperTest extends \PHPUnit_Framework_TestCase
     {
         $dt = new \DateTimeImmutable($dateString);
 
+        $this->assertEquals($expectedOutput, \Contentful\format_date_for_json($dt));
         $this->assertEquals($expectedOutput, DateHelper::formatForJson($dt));
     }
 


### PR DESCRIPTION
This PR removes the use of helpers `DateHelper` and `JsonHelper`, which will be deprecated in v2.2 and removed in v3.

JsonHelper is replaced by corresponding functions already provided by Guzzle, which do a very similar thing (wrapping the default `json_*` functions and throwing exception in case of failure). For compatibility reason, JsonHelper still catches Guzzle's exceptions (InvalidArgumentException) and then re-throws another type (RuntimeException), which is the same as before, so nothing should actually change for users relying on these methods.
`DateHelper:: formatForJson` is replaced by a simple function defined in `src/functions.php`, with the same signature.