### PR TITLE
Add an easier way to sync

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,7 @@
     "require-dev": {
         "php-vcr/phpunit-testlistener-vcr": "^2.0",
         "jakub-onderka/php-parallel-lint": "^0.9.2",
-        "jakub-onderka/php-console-highlighter": "^0.3.2",
-        "phpunit/phpunit": "~4.0"
+        "jakub-onderka/php-console-highlighter": "^0.3.2"
     },
     "autoload": {
         "files": ["src/functions.php"],

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     "require-dev": {
         "php-vcr/phpunit-testlistener-vcr": "^2.0",
         "jakub-onderka/php-parallel-lint": "^0.9.2",
-        "jakub-onderka/php-console-highlighter": "^0.3.2"
+        "jakub-onderka/php-console-highlighter": "^0.3.2",
+        "phpunit/phpunit": "~4.0"
     },
     "autoload": {
         "files": ["src/functions.php"],

--- a/src/Delivery/Synchronization/Manager.php
+++ b/src/Delivery/Synchronization/Manager.php
@@ -54,6 +54,31 @@ class Manager
     }
 
     /**
+     * @param null $token
+     * @param Query|null $query
+     *
+     * @return \Generator|void
+     */
+    public function sync($token = null, Query $query = null)
+    {
+        while (true) {
+            if ($token) {
+                $result = $this->continueSync($token);
+            } else {
+                $result = $this->startSync($query);
+            }
+
+            yield $result;
+
+            if ($result->isDone()) {
+                return;
+            }
+
+            $token = $result->getToken();
+        }
+    }
+
+    /**
      * Starts a new Synchronization. Will contain all the Resources currently present in the space.
      *
      * By calling Result::isDone it can be checked if there's another page of results, if so call `continueSync` to get the next page.

--- a/src/Delivery/Synchronization/Manager.php
+++ b/src/Delivery/Synchronization/Manager.php
@@ -62,11 +62,7 @@ class Manager
     public function sync($token = null, Query $query = null)
     {
         while (true) {
-            if ($token) {
-                $result = $this->continueSync($token);
-            } else {
-                $result = $this->startSync($query);
-            }
+            $result = ($token) ? $this->continueSync($token) : $this->startSync($query);
 
             yield $result;
 

--- a/src/Delivery/Synchronization/Manager.php
+++ b/src/Delivery/Synchronization/Manager.php
@@ -54,10 +54,10 @@ class Manager
     }
 
     /**
-     * @param null $token
+     * @param string|null $token
      * @param Query|null $query
      *
-     * @return \Generator|void
+     * @return \Generator|Result[]
      */
     public function sync($token = null, Query $query = null)
     {

--- a/tests/E2E/SyncTest.php
+++ b/tests/E2E/SyncTest.php
@@ -64,4 +64,23 @@ class SyncTest extends End2EndTestCase
         $result = $manager->startSync();
         $manager->continueSync($result);
     }
+
+    /**
+     * @requires API no-coverage-proxy
+     * @vcr e2e_sync.json
+     */
+    public function testSync()
+    {
+        $manager = $this->getClient('cfexampleapi')
+            ->getSynchronizationManager();
+
+        $results = [];
+        foreach ($manager->sync() as $result) {
+            $results[] = $result;
+        }
+
+        $this->assertEquals(2, count($results));
+        $this->assertTrue($result->isDone());
+        $this->assertEquals('w5ZGw6JFwqZmVcKsE8Kow4grw45QdybCnV_Cg8OASMKpwo1UY8K8bsKFwqJrw7DDhcKnM2RDOVbDt1E-wo7CnDjChMKKGsK1wrzCrBzCqMOpZAwOOcOvCcOAwqHDv0XCiMKaOcOxZA8BJUzDr8K-wo1lNx7DnHE', $result->getToken());
+    }
 }

--- a/tests/recordings/e2e_sync.json
+++ b/tests/recordings/e2e_sync.json
@@ -1,0 +1,319 @@
+[{
+    "request": {
+        "method": "GET",
+        "url": "https:\/\/cdn.contentful.com\/spaces\/cfexampleapi\/sync?initial=1",
+        "headers": {
+            "Host": "cdn.contentful.com",
+            "User-Agent": "GuzzleHttp\/6.2.1 curl\/7.51.0 PHP\/7.1.4",
+            "X-Contentful-User-Agent": "sdk contentful.php\/2.1.0-dev; platform PHP\/7.1.4; os macOS;",
+            "Accept": "application\/vnd.contentful.delivery.v1+json",
+            "Accept-Encoding": "gzip",
+            "Authorization": "Bearer b4c0n73n7fu1"
+        }
+    },
+    "response": {
+        "status": {
+            "http_version": "1.1",
+            "code": "200",
+            "message": "OK"
+        },
+        "headers": {
+            "Access-Control-Allow-Headers": "Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent",
+            "Access-Control-Allow-Methods": "GET,HEAD,OPTIONS",
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Expose-Headers": "Etag",
+            "Access-Control-Max-Age": "86400",
+            "Cache-Control": "max-age=0",
+            "Content-Encoding": "gzip",
+            "Content-Type": "application\/vnd.contentful.delivery.v1+json",
+            "ETag": "W\/\"9c69382c9e410a421b14caaf0add60b4\"",
+            "Server": "Contentful",
+            "X-Content-Type-Options": "nosniff",
+            "X-Contentful-Request-Id": "3971dbb8e86978fdf39faee7dbfc4938",
+            "Content-Length": "2159",
+            "Accept-Ranges": "bytes",
+            "Date": "Thu, 06 Jul 2017 11:37:35 GMT",
+            "Via": "1.1 varnish",
+            "Age": "0",
+            "Connection": "keep-alive",
+            "X-Served-By": "cache-hhn1536-HHN",
+            "X-Cache": "MISS",
+            "X-Cache-Hits": "0",
+            "X-Timer": "S1499341055.257457,VS0,VE180",
+            "Vary": "Accept-Encoding"
+        },
+        "body": "{\n  \"sys\": {\n    \"type\": \"Array\"\n  },\n  \"items\": [\n    {\n      \"sys\": {\n        \"space\": {\n          \"sys\": {\n            \"type\": \"Link\",\n            \"linkType\": \"Space\",\n            \"id\": \"cfexampleapi\"\n          }\n        },\n        \"id\": \"5ETMRzkl9KM4omyMwKAOki\",\n        \"type\": \"Entry\",\n        \"createdAt\": \"2014-02-21T13:42:57.752Z\",\n        \"updatedAt\": \"2014-08-23T14:42:35.207Z\",\n        \"revision\": 3,\n        \"contentType\": {\n          \"sys\": {\n            \"type\": \"Link\",\n            \"linkType\": \"ContentType\",\n            \"id\": \"1t9IbcfdCk6m04uISSsaIK\"\n          }\n        }\n      },\n      \"fields\": {\n        \"name\": {\n          \"en-US\": \"London\"\n        },\n        \"center\": {\n          \"en-US\": {\n            \"lon\": -0.12548719999995228,\n            \"lat\": 51.508515\n          }\n        }\n      }\n    },\n    {\n      \"sys\": {\n        \"space\": {\n          \"sys\": {\n            \"type\": \"Link\",\n            \"linkType\": \"Space\",\n            \"id\": \"cfexampleapi\"\n          }\n        },\n        \"id\": \"7qVBlCjpWE86Oseo40gAEY\",\n        \"type\": \"Entry\",\n        \"createdAt\": \"2014-02-21T13:43:38.258Z\",\n        \"updatedAt\": \"2014-04-15T08:22:22.010Z\",\n        \"revision\": 2,\n        \"contentType\": {\n          \"sys\": {\n            \"type\": \"Link\",\n            \"linkType\": \"ContentType\",\n            \"id\": \"1t9IbcfdCk6m04uISSsaIK\"\n          }\n        }\n      },\n      \"fields\": {\n        \"name\": {\n          \"en-US\": \"San Francisco\"\n        },\n        \"center\": {\n          \"en-US\": {\n            \"lon\": -122.41941550000001,\n            \"lat\": 37.7749295\n          }\n        }\n      }\n    },\n    {\n      \"sys\": {\n        \"space\": {\n          \"sys\": {\n            \"type\": \"Link\",\n            \"linkType\": \"Space\",\n            \"id\": \"cfexampleapi\"\n          }\n        },\n        \"id\": \"ge1xHyH3QOWucKWCCAgIG\",\n        \"type\": \"Entry\",\n        \"createdAt\": \"2014-02-21T13:43:23.210Z\",\n        \"updatedAt\": \"2014-02-21T13:43:23.210Z\",\n        \"revision\": 1,\n        \"contentType\": {\n          \"sys\": {\n            \"type\": \"Link\",\n            \"linkType\": \"ContentType\",\n            \"id\": \"1t9IbcfdCk6m04uISSsaIK\"\n          }\n        }\n      },\n      \"fields\": {\n        \"name\": {\n          \"en-US\": \"Paris\"\n        },\n        \"center\": {\n          \"en-US\": {\n            \"lon\": 2.3522219000000177,\n            \"lat\": 48.856614\n          }\n        }\n      }\n    },\n    {\n      \"sys\": {\n        \"space\": {\n          \"sys\": {\n            \"type\": \"Link\",\n            \"linkType\": \"Space\",\n            \"id\": \"cfexampleapi\"\n          }\n        },\n        \"id\": \"4MU1s3potiUEM2G4okYOqw\",\n        \"type\": \"Entry\",\n        \"createdAt\": \"2014-02-21T13:42:45.926Z\",\n        \"updatedAt\": \"2014-02-21T13:42:45.926Z\",\n        \"revision\": 1,\n        \"contentType\": {\n          \"sys\": {\n            \"type\": \"Link\",\n            \"linkType\": \"ContentType\",\n            \"id\": \"1t9IbcfdCk6m04uISSsaIK\"\n          }\n        }\n      },\n      \"fields\": {\n        \"name\": {\n          \"en-US\": \"Berlin\"\n        },\n        \"center\": {\n          \"en-US\": {\n            \"lon\": 13.404953999999975,\n            \"lat\": 52.52000659999999\n          }\n        }\n      }\n    },\n    {\n      \"sys\": {\n        \"space\": {\n          \"sys\": {\n            \"type\": \"Link\",\n            \"linkType\": \"Space\",\n            \"id\": \"cfexampleapi\"\n          }\n        },\n        \"id\": \"1x0xpXu4pSGS4OukSyWGUK\",\n        \"type\": \"Asset\",\n        \"createdAt\": \"2013-11-06T09:45:10.000Z\",\n        \"updatedAt\": \"2013-12-18T13:27:14.917Z\",\n        \"revision\": 6\n      },\n      \"fields\": {\n        \"title\": {\n          \"en-US\": \"Doge\"\n        },\n        \"description\": {\n          \"en-US\": \"nice picture\"\n        },\n        \"file\": {\n          \"en-US\": {\n            \"url\": \"\/\/images.contentful.com\/cfexampleapi\/1x0xpXu4pSGS4OukSyWGUK\/cc1239c6385428ef26f4180190532818\/doge.jpg\",\n            \"details\": {\n              \"size\": 522943,\n              \"image\": {\n                \"width\": 5800,\n                \"height\": 4350\n              }\n            },\n            \"fileName\": \"doge.jpg\",\n            \"contentType\": \"image\/jpeg\"\n          }\n        }\n      }\n    },\n    {\n      \"sys\": {\n        \"space\": {\n          \"sys\": {\n            \"type\": \"Link\",\n            \"linkType\": \"Space\",\n            \"id\": \"cfexampleapi\"\n          }\n        },\n        \"id\": \"jake\",\n        \"type\": \"Entry\",\n        \"createdAt\": \"2013-06-27T22:46:22.096Z\",\n        \"updatedAt\": \"2013-12-18T13:10:26.212Z\",\n        \"revision\": 5,\n        \"contentType\": {\n          \"sys\": {\n            \"type\": \"Link\",\n            \"linkType\": \"ContentType\",\n            \"id\": \"dog\"\n          }\n        }\n      },\n      \"fields\": {\n        \"name\": {\n          \"en-US\": \"Jake\"\n        },\n        \"description\": {\n          \"en-US\": \"Bacon pancakes, makin' bacon pancakes!\"\n        },\n        \"image\": {\n          \"en-US\": {\n            \"sys\": {\n              \"type\": \"Link\",\n              \"linkType\": \"Asset\",\n              \"id\": \"jake\"\n            }\n          }\n        }\n      }\n    },\n    {\n      \"sys\": {\n        \"space\": {\n          \"sys\": {\n            \"type\": \"Link\",\n            \"linkType\": \"Space\",\n            \"id\": \"cfexampleapi\"\n          }\n        },\n        \"id\": \"happycat\",\n        \"type\": \"Entry\",\n        \"createdAt\": \"2013-06-27T22:46:20.171Z\",\n        \"updatedAt\": \"2013-11-18T15:58:02.018Z\",\n        \"revision\": 8,\n        \"contentType\": {\n          \"sys\": {\n            \"type\": \"Link\",\n            \"linkType\": \"ContentType\",\n            \"id\": \"cat\"\n          }\n        }\n      },\n      \"fields\": {\n        \"name\": {\n          \"en-US\": \"Happy Cat\",\n          \"tlh\": \"Quch vIghro'\"\n        },\n        \"likes\": {\n          \"en-US\": [\n            \"cheezburger\"\n          ]\n        },\n        \"color\": {\n          \"en-US\": \"gray\"\n        },\n        \"bestFriend\": {\n          \"en-US\": {\n            \"sys\": {\n              \"type\": \"Link\",\n              \"linkType\": \"Entry\",\n              \"id\": \"nyancat\"\n            }\n          }\n        },\n        \"birthday\": {\n          \"en-US\": \"2003-10-28T23:00:00+00:00\"\n        },\n        \"lives\": {\n          \"en-US\": 1\n        },\n        \"image\": {\n          \"en-US\": {\n            \"sys\": {\n              \"type\": \"Link\",\n              \"linkType\": \"Asset\",\n              \"id\": \"happycat\"\n            }\n          }\n        }\n      }\n    },\n    {\n      \"sys\": {\n        \"space\": {\n          \"sys\": {\n            \"type\": \"Link\",\n            \"linkType\": \"Space\",\n            \"id\": \"cfexampleapi\"\n          }\n        },\n        \"id\": \"6KntaYXaHSyIw8M6eo26OK\",\n        \"type\": \"Entry\",\n        \"createdAt\": \"2013-11-06T09:45:27.475Z\",\n        \"updatedAt\": \"2013-11-18T09:13:37.808Z\",\n        \"revision\": 2,\n        \"contentType\": {\n          \"sys\": {\n            \"type\": \"Link\",\n            \"linkType\": \"ContentType\",\n            \"id\": \"dog\"\n          }\n        }\n      },\n      \"fields\": {\n        \"name\": {\n          \"en-US\": \"Doge\"\n        },\n        \"description\": {\n          \"en-US\": \"such json\\nwow\"\n        },\n        \"image\": {\n          \"en-US\": {\n            \"sys\": {\n              \"type\": \"Link\",\n              \"linkType\": \"Asset\",\n              \"id\": \"1x0xpXu4pSGS4OukSyWGUK\"\n            }\n          }\n        }\n      }\n    },\n    {\n      \"sys\": {\n        \"space\": {\n          \"sys\": {\n            \"type\": \"Link\",\n            \"linkType\": \"Space\",\n            \"id\": \"cfexampleapi\"\n          }\n        },\n        \"id\": \"finn\",\n        \"type\": \"Entry\",\n        \"createdAt\": \"2013-06-27T22:46:21.450Z\",\n        \"updatedAt\": \"2013-09-09T16:15:01.297Z\",\n        \"revision\": 6,\n        \"contentType\": {\n          \"sys\": {\n            \"type\": \"Link\",\n            \"linkType\": \"ContentType\",\n            \"id\": \"human\"\n          }\n        }\n      },\n      \"fields\": {\n        \"name\": {\n          \"en-US\": \"Finn\"\n        },\n        \"description\": {\n          \"en-US\": \"Fearless adventurer! Defender of pancakes.\"\n        },\n        \"likes\": {\n          \"en-US\": [\n            \"adventure\"\n          ]\n        }\n      }\n    },\n    {\n      \"sys\": {\n        \"space\": {\n          \"sys\": {\n            \"type\": \"Link\",\n            \"linkType\": \"Space\",\n            \"id\": \"cfexampleapi\"\n          }\n        },\n        \"id\": \"nyancat\",\n        \"type\": \"Entry\",\n        \"createdAt\": \"2013-06-27T22:46:19.513Z\",\n        \"updatedAt\": \"2013-09-04T09:19:39.027Z\",\n        \"revision\": 5,\n        \"contentType\": {\n          \"sys\": {\n            \"type\": \"Link\",\n            \"linkType\": \"ContentType\",\n            \"id\": \"cat\"\n          }\n        }\n      },\n      \"fields\": {\n        \"name\": {\n          \"en-US\": \"Nyan Cat\",\n          \"tlh\": \"Nyan vIghro'\"\n        },\n        \"likes\": {\n          \"en-US\": [\n            \"rainbows\",\n            \"fish\"\n          ]\n        },\n        \"color\": {\n          \"en-US\": \"rainbow\"\n        },\n        \"bestFriend\": {\n          \"en-US\": {\n            \"sys\": {\n              \"type\": \"Link\",\n              \"linkType\": \"Entry\",\n              \"id\": \"happycat\"\n            }\n          }\n        },\n        \"birthday\": {\n          \"en-US\": \"2011-04-04T22:00:00+00:00\"\n        },\n        \"lives\": {\n          \"en-US\": 1337\n        },\n        \"image\": {\n          \"en-US\": {\n            \"sys\": {\n              \"type\": \"Link\",\n              \"linkType\": \"Asset\",\n              \"id\": \"nyancat\"\n            }\n          }\n        }\n      }\n    },\n    {\n      \"sys\": {\n        \"space\": {\n          \"sys\": {\n            \"type\": \"Link\",\n            \"linkType\": \"Space\",\n            \"id\": \"cfexampleapi\"\n          }\n        },\n        \"id\": \"jake\",\n        \"type\": \"Asset\",\n        \"createdAt\": \"2013-09-02T14:56:34.260Z\",\n        \"updatedAt\": \"2013-09-02T15:22:39.466Z\",\n        \"revision\": 2\n      },\n      \"fields\": {\n        \"title\": {\n          \"en-US\": \"Jake\"\n        },\n        \"file\": {\n          \"en-US\": {\n            \"url\": \"\/\/images.contentful.com\/cfexampleapi\/4hlteQAXS8iS0YCMU6QMWg\/2a4d826144f014109364ccf5c891d2dd\/jake.png\",\n            \"details\": {\n              \"size\": 20480,\n              \"image\": {\n                \"width\": 100,\n                \"height\": 161\n              }\n            },\n            \"fileName\": \"jake.png\",\n            \"contentType\": \"image\/png\"\n          }\n        }\n      }\n    },\n    {\n      \"sys\": {\n        \"space\": {\n          \"sys\": {\n            \"type\": \"Link\",\n            \"linkType\": \"Space\",\n            \"id\": \"cfexampleapi\"\n          }\n        },\n        \"id\": \"happycat\",\n        \"type\": \"Asset\",\n        \"createdAt\": \"2013-09-02T14:56:34.267Z\",\n        \"updatedAt\": \"2013-09-02T15:11:24.361Z\",\n        \"revision\": 2\n      },\n      \"fields\": {\n        \"title\": {\n          \"en-US\": \"Happy Cat\"\n        },\n        \"file\": {\n          \"en-US\": {\n            \"url\": \"\/\/images.contentful.com\/cfexampleapi\/3MZPnjZTIskAIIkuuosCss\/382a48dfa2cb16c47aa2c72f7b23bf09\/happycatw.jpg\",\n            \"details\": {\n              \"size\": 59939,\n              \"image\": {\n                \"width\": 273,\n                \"height\": 397\n              }\n            },\n            \"fileName\": \"happycatw.jpg\",\n            \"contentType\": \"image\/jpeg\"\n          }\n        }\n      }\n    },\n    {\n      \"sys\": {\n        \"space\": {\n          \"sys\": {\n            \"type\": \"Link\",\n            \"linkType\": \"Space\",\n            \"id\": \"cfexampleapi\"\n          }\n        },\n        \"id\": \"nyancat\",\n        \"type\": \"Asset\",\n        \"createdAt\": \"2013-09-02T14:56:34.240Z\",\n        \"updatedAt\": \"2013-09-02T14:56:34.240Z\",\n        \"revision\": 1\n      },\n      \"fields\": {\n        \"title\": {\n          \"en-US\": \"Nyan Cat\"\n        },\n        \"file\": {\n          \"en-US\": {\n            \"url\": \"\/\/images.contentful.com\/cfexampleapi\/4gp6taAwW4CmSgumq2ekUm\/9da0cd1936871b8d72343e895a00d611\/Nyan_cat_250px_frame.png\",\n            \"details\": {\n              \"size\": 12273,\n              \"image\": {\n                \"width\": 250,\n                \"height\": 250\n              }\n            },\n            \"fileName\": \"Nyan_cat_250px_frame.png\",\n            \"contentType\": \"image\/png\"\n          }\n        }\n      }\n    },\n    {\n      \"sys\": {\n        \"space\": {\n          \"sys\": {\n            \"type\": \"Link\",\n            \"linkType\": \"Space\",\n            \"id\": \"cfexampleapi\"\n          }\n        },\n        \"id\": \"garfield\",\n        \"type\": \"Entry\",\n        \"createdAt\": \"2013-06-27T22:46:20.821Z\",\n        \"updatedAt\": \"2013-08-27T10:09:07.929Z\",\n        \"revision\": 2,\n        \"contentType\": {\n          \"sys\": {\n            \"type\": \"Link\",\n            \"linkType\": \"ContentType\",\n            \"id\": \"cat\"\n          }\n        }\n      },\n      \"fields\": {\n        \"name\": {\n          \"en-US\": \"Garfield\",\n          \"tlh\": \"Garfield\"\n        },\n        \"likes\": {\n          \"en-US\": [\n            \"lasagna\"\n          ]\n        },\n        \"color\": {\n          \"en-US\": \"orange\"\n        },\n        \"birthday\": {\n          \"en-US\": \"1979-06-18T23:00:00+00:00\"\n        },\n        \"lifes\": {\n          \"en-US\": null\n        },\n        \"lives\": {\n          \"en-US\": 9\n        }\n      }\n    }\n  ],\n  \"nextPageUrl\": \"https:\/\/cdn.contentful.com\/spaces\/cfexampleapi\/sync?sync_token=w5ZGw6JFwqZmVcKsE8Kow4grw45QdybCnV_Cg8OASMKpwo1UY8K8bsKFwqJrw7DDhcKnM2RDOVbDt1E-wo7CnDjChMKKGsK1wrzCrBzCqMOpZAwOOcOvCcOAwqHDv0XCiMKaOcOxZA8BJUzDr8K-wo1lNx7DnHE\"\n}\n"
+    }
+},{
+    "request": {
+        "method": "GET",
+        "url": "https:\/\/cdn.contentful.com\/spaces\/cfexampleapi\/",
+        "headers": {
+            "Host": "cdn.contentful.com",
+            "User-Agent": "GuzzleHttp\/6.2.1 curl\/7.51.0 PHP\/7.1.4",
+            "X-Contentful-User-Agent": "sdk contentful.php\/2.1.0-dev; platform PHP\/7.1.4; os macOS;",
+            "Accept": "application\/vnd.contentful.delivery.v1+json",
+            "Accept-Encoding": "gzip",
+            "Authorization": "Bearer b4c0n73n7fu1"
+        }
+    },
+    "response": {
+        "status": {
+            "http_version": "1.1",
+            "code": "200",
+            "message": "OK"
+        },
+        "headers": {
+            "Access-Control-Allow-Headers": "Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent",
+            "Access-Control-Allow-Methods": "GET,HEAD,OPTIONS",
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Expose-Headers": "Etag",
+            "Access-Control-Max-Age": "86400",
+            "Cache-Control": "max-age=0",
+            "Content-Type": "application\/vnd.contentful.delivery.v1+json",
+            "ETag": "\"17f6b9f68596176aed46fa020bf235af\"",
+            "Server": "Contentful",
+            "X-Content-Type-Options": "nosniff",
+            "X-Contentful-Request-Id": "619faf018600aa22a357db0a4914a39f",
+            "Content-Length": "344",
+            "Accept-Ranges": "bytes",
+            "Date": "Thu, 06 Jul 2017 11:37:35 GMT",
+            "Via": "1.1 varnish",
+            "Age": "53",
+            "Connection": "keep-alive",
+            "X-Served-By": "cache-hhn1537-HHN",
+            "X-Cache": "HIT",
+            "X-Cache-Hits": "1",
+            "X-Timer": "S1499341056.878865,VS0,VE0",
+            "Vary": "Accept-Encoding"
+        },
+        "body": "{\n  \"sys\": {\n    \"type\": \"Space\",\n    \"id\": \"cfexampleapi\"\n  },\n  \"name\": \"Contentful Example API\",\n  \"locales\": [\n    {\n      \"code\": \"en-US\",\n      \"default\": true,\n      \"name\": \"English\",\n      \"fallbackCode\": null\n    },\n    {\n      \"code\": \"tlh\",\n      \"default\": false,\n      \"name\": \"Klingon\",\n      \"fallbackCode\": \"en-US\"\n    }\n  ]\n}\n"
+    }
+},{
+    "request": {
+        "method": "GET",
+        "url": "https:\/\/cdn.contentful.com\/spaces\/cfexampleapi\/content_types\/1t9IbcfdCk6m04uISSsaIK",
+        "headers": {
+            "Host": "cdn.contentful.com",
+            "User-Agent": "GuzzleHttp\/6.2.1 curl\/7.51.0 PHP\/7.1.4",
+            "X-Contentful-User-Agent": "sdk contentful.php\/2.1.0-dev; platform PHP\/7.1.4; os macOS;",
+            "Accept": "application\/vnd.contentful.delivery.v1+json",
+            "Accept-Encoding": "gzip",
+            "Authorization": "Bearer b4c0n73n7fu1"
+        }
+    },
+    "response": {
+        "status": {
+            "http_version": "1.1",
+            "code": "200",
+            "message": "OK"
+        },
+        "headers": {
+            "Access-Control-Allow-Headers": "Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent",
+            "Access-Control-Allow-Methods": "GET,HEAD,OPTIONS",
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Expose-Headers": "Etag",
+            "Access-Control-Max-Age": "86400",
+            "Cache-Control": "max-age=0",
+            "Content-Type": "application\/vnd.contentful.delivery.v1+json",
+            "ETag": "\"4b946b8682dd023d48992ae24c000e2e\"",
+            "Server": "Contentful",
+            "X-Content-Type-Options": "nosniff",
+            "X-Contentful-Request-Id": "f9baa5dcbf1522e1a2e6c053864acf3c",
+            "Content-Length": "760",
+            "Accept-Ranges": "bytes",
+            "Date": "Thu, 06 Jul 2017 11:37:36 GMT",
+            "Via": "1.1 varnish",
+            "Age": "46",
+            "Connection": "keep-alive",
+            "X-Served-By": "cache-hhn1528-HHN",
+            "X-Cache": "HIT",
+            "X-Cache-Hits": "2",
+            "X-Timer": "S1499341057.760594,VS0,VE0",
+            "Vary": "Accept-Encoding"
+        },
+        "body": "{\n  \"sys\": {\n    \"space\": {\n      \"sys\": {\n        \"type\": \"Link\",\n        \"linkType\": \"Space\",\n        \"id\": \"cfexampleapi\"\n      }\n    },\n    \"id\": \"1t9IbcfdCk6m04uISSsaIK\",\n    \"type\": \"ContentType\",\n    \"createdAt\": \"2014-02-21T13:42:33.009Z\",\n    \"updatedAt\": \"2014-02-21T13:42:33.009Z\",\n    \"revision\": 1\n  },\n  \"displayField\": \"name\",\n  \"name\": \"City\",\n  \"description\": null,\n  \"fields\": [\n    {\n      \"id\": \"name\",\n      \"name\": \"Name\",\n      \"type\": \"Text\",\n      \"localized\": false,\n      \"required\": true,\n      \"disabled\": false,\n      \"omitted\": false\n    },\n    {\n      \"id\": \"center\",\n      \"name\": \"Center\",\n      \"type\": \"Location\",\n      \"localized\": false,\n      \"required\": true,\n      \"disabled\": false,\n      \"omitted\": false\n    }\n  ]\n}\n"
+    }
+},{
+    "request": {
+        "method": "GET",
+        "url": "https:\/\/cdn.contentful.com\/spaces\/cfexampleapi\/content_types\/dog",
+        "headers": {
+            "Host": "cdn.contentful.com",
+            "User-Agent": "GuzzleHttp\/6.2.1 curl\/7.51.0 PHP\/7.1.4",
+            "X-Contentful-User-Agent": "sdk contentful.php\/2.1.0-dev; platform PHP\/7.1.4; os macOS;",
+            "Accept": "application\/vnd.contentful.delivery.v1+json",
+            "Accept-Encoding": "gzip",
+            "Authorization": "Bearer b4c0n73n7fu1"
+        }
+    },
+    "response": {
+        "status": {
+            "http_version": "1.1",
+            "code": "200",
+            "message": "OK"
+        },
+        "headers": {
+            "Access-Control-Allow-Headers": "Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent",
+            "Access-Control-Allow-Methods": "GET,HEAD,OPTIONS",
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Expose-Headers": "Etag",
+            "Access-Control-Max-Age": "86400",
+            "Cache-Control": "max-age=0",
+            "Content-Type": "application\/vnd.contentful.delivery.v1+json",
+            "ETag": "\"47105ca4f2da4279fcd74f0ecb349236\"",
+            "Server": "Contentful",
+            "X-Content-Type-Options": "nosniff",
+            "X-Contentful-Request-Id": "421cf08234b50ddf93dac70405a103bb",
+            "Content-Length": "955",
+            "Accept-Ranges": "bytes",
+            "Date": "Thu, 06 Jul 2017 11:37:37 GMT",
+            "Via": "1.1 varnish",
+            "Age": "46",
+            "Connection": "keep-alive",
+            "X-Served-By": "cache-hhn1532-HHN",
+            "X-Cache": "HIT",
+            "X-Cache-Hits": "1",
+            "X-Timer": "S1499341058.649664,VS0,VE0",
+            "Vary": "Accept-Encoding"
+        },
+        "body": "{\n  \"sys\": {\n    \"space\": {\n      \"sys\": {\n        \"type\": \"Link\",\n        \"linkType\": \"Space\",\n        \"id\": \"cfexampleapi\"\n      }\n    },\n    \"id\": \"dog\",\n    \"type\": \"ContentType\",\n    \"createdAt\": \"2013-06-27T22:46:13.498Z\",\n    \"updatedAt\": \"2013-09-02T14:32:11.837Z\",\n    \"revision\": 2\n  },\n  \"displayField\": \"name\",\n  \"name\": \"Dog\",\n  \"description\": \"Bark!\",\n  \"fields\": [\n    {\n      \"id\": \"name\",\n      \"name\": \"Name\",\n      \"type\": \"Text\",\n      \"localized\": false,\n      \"required\": true,\n      \"disabled\": false,\n      \"omitted\": false\n    },\n    {\n      \"id\": \"description\",\n      \"name\": \"Description\",\n      \"type\": \"Text\",\n      \"localized\": false,\n      \"required\": false,\n      \"disabled\": false,\n      \"omitted\": false\n    },\n    {\n      \"id\": \"image\",\n      \"name\": \"Image\",\n      \"type\": \"Link\",\n      \"localized\": false,\n      \"required\": false,\n      \"disabled\": false,\n      \"omitted\": false,\n      \"linkType\": \"Asset\"\n    }\n  ]\n}\n"
+    }
+},{
+    "request": {
+        "method": "GET",
+        "url": "https:\/\/cdn.contentful.com\/spaces\/cfexampleapi\/content_types\/cat",
+        "headers": {
+            "Host": "cdn.contentful.com",
+            "User-Agent": "GuzzleHttp\/6.2.1 curl\/7.51.0 PHP\/7.1.4",
+            "X-Contentful-User-Agent": "sdk contentful.php\/2.1.0-dev; platform PHP\/7.1.4; os macOS;",
+            "Accept": "application\/vnd.contentful.delivery.v1+json",
+            "Accept-Encoding": "gzip",
+            "Authorization": "Bearer b4c0n73n7fu1"
+        }
+    },
+    "response": {
+        "status": {
+            "http_version": "1.1",
+            "code": "200",
+            "message": "OK"
+        },
+        "headers": {
+            "Access-Control-Allow-Headers": "Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent",
+            "Access-Control-Allow-Methods": "GET,HEAD,OPTIONS",
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Expose-Headers": "Etag",
+            "Access-Control-Max-Age": "86400",
+            "Cache-Control": "max-age=0",
+            "Content-Encoding": "gzip",
+            "Content-Type": "application\/vnd.contentful.delivery.v1+json",
+            "ETag": "W\/\"8f387b5b6a95416d52c98f2832c5c929\"",
+            "Server": "Contentful",
+            "X-Content-Type-Options": "nosniff",
+            "X-Contentful-Request-Id": "b1db4462df715b9ef069340400795942",
+            "Content-Length": "517",
+            "Accept-Ranges": "bytes",
+            "Date": "Thu, 06 Jul 2017 11:37:38 GMT",
+            "Via": "1.1 varnish",
+            "Age": "51",
+            "Connection": "keep-alive",
+            "X-Served-By": "cache-hhn1547-HHN",
+            "X-Cache": "HIT",
+            "X-Cache-Hits": "1",
+            "X-Timer": "S1499341059.633111,VS0,VE1",
+            "Vary": "Accept-Encoding"
+        },
+        "body": "{\n  \"sys\": {\n    \"space\": {\n      \"sys\": {\n        \"type\": \"Link\",\n        \"linkType\": \"Space\",\n        \"id\": \"cfexampleapi\"\n      }\n    },\n    \"id\": \"cat\",\n    \"type\": \"ContentType\",\n    \"createdAt\": \"2013-06-27T22:46:12.852Z\",\n    \"updatedAt\": \"2017-07-06T09:58:52.691Z\",\n    \"revision\": 8\n  },\n  \"displayField\": \"name\",\n  \"name\": \"Cat\",\n  \"description\": \"Meow.\",\n  \"fields\": [\n    {\n      \"id\": \"name\",\n      \"name\": \"Name\",\n      \"type\": \"Text\",\n      \"localized\": true,\n      \"required\": true,\n      \"disabled\": false,\n      \"omitted\": false\n    },\n    {\n      \"id\": \"likes\",\n      \"name\": \"Likes\",\n      \"type\": \"Array\",\n      \"localized\": false,\n      \"required\": false,\n      \"disabled\": false,\n      \"omitted\": false,\n      \"items\": {\n        \"type\": \"Symbol\",\n        \"validations\": []\n      }\n    },\n    {\n      \"id\": \"color\",\n      \"name\": \"Color\",\n      \"type\": \"Symbol\",\n      \"localized\": false,\n      \"required\": false,\n      \"disabled\": false,\n      \"omitted\": false\n    },\n    {\n      \"id\": \"bestFriend\",\n      \"name\": \"Best Friend\",\n      \"type\": \"Link\",\n      \"localized\": false,\n      \"required\": false,\n      \"disabled\": false,\n      \"omitted\": false,\n      \"linkType\": \"Entry\"\n    },\n    {\n      \"id\": \"birthday\",\n      \"name\": \"Birthday\",\n      \"type\": \"Date\",\n      \"localized\": false,\n      \"required\": false,\n      \"disabled\": false,\n      \"omitted\": false\n    },\n    {\n      \"id\": \"lifes\",\n      \"name\": \"Lifes left\",\n      \"type\": \"Integer\",\n      \"localized\": false,\n      \"required\": false,\n      \"disabled\": true,\n      \"omitted\": false\n    },\n    {\n      \"id\": \"lives\",\n      \"name\": \"Lives left\",\n      \"type\": \"Integer\",\n      \"localized\": false,\n      \"required\": false,\n      \"disabled\": false,\n      \"omitted\": false\n    },\n    {\n      \"id\": \"image\",\n      \"name\": \"Image\",\n      \"type\": \"Link\",\n      \"localized\": false,\n      \"required\": false,\n      \"disabled\": false,\n      \"omitted\": false,\n      \"linkType\": \"Asset\"\n    }\n  ]\n}\n"
+    }
+},{
+    "request": {
+        "method": "GET",
+        "url": "https:\/\/cdn.contentful.com\/spaces\/cfexampleapi\/content_types\/human",
+        "headers": {
+            "Host": "cdn.contentful.com",
+            "User-Agent": "GuzzleHttp\/6.2.1 curl\/7.51.0 PHP\/7.1.4",
+            "X-Contentful-User-Agent": "sdk contentful.php\/2.1.0-dev; platform PHP\/7.1.4; os macOS;",
+            "Accept": "application\/vnd.contentful.delivery.v1+json",
+            "Accept-Encoding": "gzip",
+            "Authorization": "Bearer b4c0n73n7fu1"
+        }
+    },
+    "response": {
+        "status": {
+            "http_version": "1.1",
+            "code": "200",
+            "message": "OK"
+        },
+        "headers": {
+            "Access-Control-Allow-Headers": "Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent",
+            "Access-Control-Allow-Methods": "GET,HEAD,OPTIONS",
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Expose-Headers": "Etag",
+            "Access-Control-Max-Age": "86400",
+            "Cache-Control": "max-age=0",
+            "Content-Encoding": "gzip",
+            "Content-Type": "application\/vnd.contentful.delivery.v1+json",
+            "ETag": "W\/\"33acd862ac64172571d117020e1c74e0\"",
+            "Server": "Contentful",
+            "X-Content-Type-Options": "nosniff",
+            "X-Contentful-Request-Id": "1d25b7513c0dfa744ab611e3382d0c23",
+            "Content-Length": "420",
+            "Accept-Ranges": "bytes",
+            "Date": "Thu, 06 Jul 2017 11:37:39 GMT",
+            "Via": "1.1 varnish",
+            "Age": "47",
+            "Connection": "keep-alive",
+            "X-Served-By": "cache-hhn1532-HHN",
+            "X-Cache": "HIT",
+            "X-Cache-Hits": "1",
+            "X-Timer": "S1499341060.774204,VS0,VE0",
+            "Vary": "Accept-Encoding"
+        },
+        "body": "{\n  \"sys\": {\n    \"space\": {\n      \"sys\": {\n        \"type\": \"Link\",\n        \"linkType\": \"Space\",\n        \"id\": \"cfexampleapi\"\n      }\n    },\n    \"id\": \"human\",\n    \"type\": \"ContentType\",\n    \"createdAt\": \"2013-06-27T22:46:14.133Z\",\n    \"updatedAt\": \"2013-09-02T15:10:26.818Z\",\n    \"revision\": 3\n  },\n  \"displayField\": \"name\",\n  \"name\": \"Human\",\n  \"description\": null,\n  \"fields\": [\n    {\n      \"id\": \"name\",\n      \"name\": \"Name\",\n      \"type\": \"Text\",\n      \"localized\": false,\n      \"required\": true,\n      \"disabled\": false,\n      \"omitted\": false\n    },\n    {\n      \"id\": \"description\",\n      \"name\": \"Description\",\n      \"type\": \"Text\",\n      \"localized\": false,\n      \"required\": false,\n      \"disabled\": false,\n      \"omitted\": false\n    },\n    {\n      \"id\": \"likes\",\n      \"name\": \"Likes\",\n      \"type\": \"Array\",\n      \"localized\": false,\n      \"required\": false,\n      \"disabled\": false,\n      \"omitted\": false,\n      \"items\": {\n        \"type\": \"Symbol\",\n        \"validations\": []\n      }\n    },\n    {\n      \"id\": \"image\",\n      \"name\": \"Image\",\n      \"type\": \"Array\",\n      \"localized\": false,\n      \"required\": false,\n      \"disabled\": true,\n      \"omitted\": false,\n      \"items\": {\n        \"type\": \"Link\",\n        \"validations\": [],\n        \"linkType\": \"Asset\"\n      }\n    }\n  ]\n}\n"
+    }
+},{
+    "request": {
+        "method": "GET",
+        "url": "https:\/\/cdn.contentful.com\/spaces\/cfexampleapi\/sync?sync_token=w5ZGw6JFwqZmVcKsE8Kow4grw45QdybCnV_Cg8OASMKpwo1UY8K8bsKFwqJrw7DDhcKnM2RDOVbDt1E-wo7CnDjChMKKGsK1wrzCrBzCqMOpZAwOOcOvCcOAwqHDv0XCiMKaOcOxZA8BJUzDr8K-wo1lNx7DnHE",
+        "headers": {
+            "Host": "cdn.contentful.com",
+            "User-Agent": "GuzzleHttp\/6.2.1 curl\/7.51.0 PHP\/7.1.4",
+            "X-Contentful-User-Agent": "sdk contentful.php\/2.1.0-dev; platform PHP\/7.1.4; os macOS;",
+            "Accept": "application\/vnd.contentful.delivery.v1+json",
+            "Accept-Encoding": "gzip",
+            "Authorization": "Bearer b4c0n73n7fu1"
+        }
+    },
+    "response": {
+        "status": {
+            "http_version": "1.1",
+            "code": "200",
+            "message": "OK"
+        },
+        "headers": {
+            "Access-Control-Allow-Headers": "Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent",
+            "Access-Control-Allow-Methods": "GET,HEAD,OPTIONS",
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Expose-Headers": "Etag",
+            "Access-Control-Max-Age": "86400",
+            "Cache-Control": "max-age=0",
+            "Content-Type": "application\/vnd.contentful.delivery.v1+json",
+            "ETag": "\"c841f2f6faad983d235700d1d04ef49d\"",
+            "Server": "Contentful",
+            "X-Content-Type-Options": "nosniff",
+            "X-Contentful-Request-Id": "132a83144ff041e75bc1ba511f79e36f",
+            "Content-Length": "297",
+            "Accept-Ranges": "bytes",
+            "Date": "Thu, 06 Jul 2017 11:37:41 GMT",
+            "Via": "1.1 varnish",
+            "Age": "0",
+            "Connection": "keep-alive",
+            "X-Served-By": "cache-hhn1529-HHN",
+            "X-Cache": "MISS",
+            "X-Cache-Hits": "0",
+            "X-Timer": "S1499341061.051822,VS0,VE299",
+            "Vary": "Accept-Encoding"
+        },
+        "body": "{\n  \"sys\": {\n    \"type\": \"Array\"\n  },\n  \"items\": [],\n  \"nextSyncUrl\": \"https:\/\/cdn.contentful.com\/spaces\/cfexampleapi\/sync?sync_token=w5ZGw6JFwqZmVcKsE8Kow4grw45QdybCnV_Cg8OASMKpwo1UY8K8bsKFwqJrw7DDhcKnM2RDOVbDt1E-wo7CnDjChMKKGsK1wrzCrBzCqMOpZAwOOcOvCcOAwqHDv0XCiMKaOcOxZA8BJUzDr8K-wo1lNx7DnHE\"\n}\n"
+    }
+}]


### PR DESCRIPTION
While playing around with the Sync Manager I thought it would be a better developer experience to just have 1 loop for syncing instead of calling multiple methods. To get all content:

```
$syncManager = $client->getSynchronizationManager();
foreach ($syncManager->sync() as $result) {
    // use the $result object how you like
}
```
Or pass a previously stored token:

```
$syncManager = $client->getSynchronizationManager();

$token = '<token from a previous sync>';
foreach ($syncManager->sync($token) as $result) {
   // use the $result object how you like
}
```

Pass a query to get specific content:
```
$syncManager = $client->getSynchronizationManager();

$query = new \Contentful\Delivery\Synchronization\Query;

foreach ($syncManager->sync(null, $query) as $result) {
    // use the $result object how you like
}
```

Because running/adding the tests did not work out of the box I added a dev requirement for phpunit/phpunit so it can be tested standalone with `php vendor/phpunit/phpunit/phpunit`.