### PR TITLE
Do not call API for included assets when using * for locale

### DIFF
--- a/src/ResourcePool.php
+++ b/src/ResourcePool.php
@@ -131,6 +131,13 @@ class ResourcePool extends BaseResourcePool
         $key = $this->generateKey($type, $id, $options);
         $this->warmUp($key, $type);
 
+        if (isset($this->resources[$key])) {
+            return true;
+        }
+
+        unset($options['locale']);
+        $key = $this->generateKey($type, $id, $options);
+
         return isset($this->resources[$key]);
     }
 
@@ -173,16 +180,23 @@ class ResourcePool extends BaseResourcePool
         $key = $this->generateKey($type, $id, $options);
         $this->warmUp($key, $type);
 
-        if (!isset($this->resources[$key])) {
-            throw new \OutOfBoundsException(\sprintf(
-                'Resource pool could not find a resource with type "%s", ID "%s"%s.',
-                $type,
-                $id,
-                $locale ? ', and locale "'.$locale.'"' : ''
-            ));
+        if (isset($this->resources[$key])) {
+            return $this->resources[$key];
         }
 
-        return $this->resources[$key];
+        unset($options['locale']);
+        $key = $this->generateKey($type, $id, $options);
+
+        if (isset($this->resources[$key])) {
+            return $this->resources[$key];
+        }
+
+        throw new \OutOfBoundsException(\sprintf(
+            'Resource pool could not find a resource with type "%s", ID "%s"%s.',
+            $type,
+            $id,
+            $locale ? ', and locale "'.$locale.'"' : ''
+        ));
     }
 
     /**

--- a/tests/E2E/EntryTest.php
+++ b/tests/E2E/EntryTest.php
@@ -160,6 +160,27 @@ class EntryTest extends TestCase
     }
 
     /**
+     * @vcr e2e_entry_assets_resolved_from_includes_all_locales_format.json
+     */
+    public function testAssetsResolvedFromIncludesWithAllLocaleFormat()
+    {
+        $client = $this->getClient('cfexampleapi');
+
+        $query = (new Query())
+            ->where('sys.id', 'nyancat')
+            ->setLocale('*');
+
+        $nyancat = $client->getEntries($query)[0];
+        $image = $nyancat->getImage();
+
+        $this->assertSame('nyancat', $image->getId());
+
+        // There should be 4 and only 4 requests:
+        // the entries with the query, the locales, the cat content type and the space call for the locale fallback.
+        $this->assertCount(4, $client->getMessages());
+    }
+
+    /**
      * @vcr e2e_entry_resolved_links_to_itself.json
      */
     public function testEntryResolvedLinksToItself()

--- a/tests/Recordings/e2e_entry_assets_resolved_from_includes_all_locales_format.json
+++ b/tests/Recordings/e2e_entry_assets_resolved_from_includes_all_locales_format.json
@@ -1,0 +1,191 @@
+[{
+    "request": {
+        "method": "GET",
+        "url": "https:\/\/cdn.contentful.com\/spaces\/cfexampleapi\/environments\/master\/entries?sys.id=nyancat&locale=%2A",
+        "headers": {
+            "Host": "cdn.contentful.com",
+            "User-Agent": "GuzzleHttp\/6.3.3 curl\/7.54.0 PHP\/7.1.22",
+            "X-Contentful-User-Agent": "sdk contentful.php\/4.0.0-dev; platform PHP\/7.1.22; os macOS;",
+            "Accept": "application\/vnd.contentful.delivery.v1+json",
+            "Accept-Encoding": "gzip",
+            "Authorization": "Bearer b4c0n73n7fu1"
+        }
+    },
+    "response": {
+        "status": {
+            "http_version": "1.1",
+            "code": "200",
+            "message": "OK"
+        },
+        "headers": {
+            "Access-Control-Allow-Headers": "Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature",
+            "Access-Control-Allow-Methods": "GET,HEAD,OPTIONS",
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Expose-Headers": "Etag",
+            "Access-Control-Max-Age": "86400",
+            "Cache-Control": "max-age=0",
+            "Content-Encoding": "gzip",
+            "Content-Type": "application\/vnd.contentful.delivery.v1+json",
+            "Contentful-Api": "cda_cached",
+            "ETag": "W\/\"b2e53f500044a310d34886f21535e4e7\"",
+            "Server": "Contentful",
+            "X-Content-Type-Options": "nosniff",
+            "X-Contentful-Region": "us-east-1",
+            "X-Contentful-Request-Id": "67723aa32b32514468e8450a55dbc12f",
+            "Content-Length": "1183",
+            "Accept-Ranges": "bytes",
+            "Date": "Fri, 19 Oct 2018 13:26:36 GMT",
+            "Via": "1.1 varnish",
+            "Age": "148",
+            "Connection": "keep-alive",
+            "X-Served-By": "cache-hhn1544-HHN",
+            "X-Cache": "HIT",
+            "X-Cache-Hits": "1",
+            "X-Timer": "S1539955597.942474,VS0,VE1",
+            "Vary": "Accept-Encoding"
+        },
+        "body": "{\n  \"sys\": {\n    \"type\": \"Array\"\n  },\n  \"total\": 1,\n  \"skip\": 0,\n  \"limit\": 100,\n  \"items\": [\n    {\n      \"sys\": {\n        \"space\": {\n          \"sys\": {\n            \"type\": \"Link\",\n            \"linkType\": \"Space\",\n            \"id\": \"cfexampleapi\"\n          }\n        },\n        \"id\": \"nyancat\",\n        \"type\": \"Entry\",\n        \"createdAt\": \"2013-06-27T22:46:19.513Z\",\n        \"updatedAt\": \"2013-09-04T09:19:39.027Z\",\n        \"environment\": {\n          \"sys\": {\n            \"id\": \"master\",\n            \"type\": \"Link\",\n            \"linkType\": \"Environment\"\n          }\n        },\n        \"revision\": 5,\n        \"contentType\": {\n          \"sys\": {\n            \"type\": \"Link\",\n            \"linkType\": \"ContentType\",\n            \"id\": \"cat\"\n          }\n        }\n      },\n      \"fields\": {\n        \"name\": {\n          \"en-US\": \"Nyan Cat\",\n          \"tlh\": \"Nyan vIghro'\"\n        },\n        \"likes\": {\n          \"en-US\": [\n            \"rainbows\",\n            \"fish\"\n          ]\n        },\n        \"color\": {\n          \"en-US\": \"rainbow\"\n        },\n        \"bestFriend\": {\n          \"en-US\": {\n            \"sys\": {\n              \"type\": \"Link\",\n              \"linkType\": \"Entry\",\n              \"id\": \"happycat\"\n            }\n          }\n        },\n        \"birthday\": {\n          \"en-US\": \"2011-04-04T22:00:00+00:00\"\n        },\n        \"lives\": {\n          \"en-US\": 1337\n        },\n        \"image\": {\n          \"en-US\": {\n            \"sys\": {\n              \"type\": \"Link\",\n              \"linkType\": \"Asset\",\n              \"id\": \"nyancat\"\n            }\n          }\n        }\n      }\n    }\n  ],\n  \"includes\": {\n    \"Entry\": [\n      {\n        \"sys\": {\n          \"space\": {\n            \"sys\": {\n              \"type\": \"Link\",\n              \"linkType\": \"Space\",\n              \"id\": \"cfexampleapi\"\n            }\n          },\n          \"id\": \"happycat\",\n          \"type\": \"Entry\",\n          \"createdAt\": \"2013-06-27T22:46:20.171Z\",\n          \"updatedAt\": \"2013-11-18T15:58:02.018Z\",\n          \"environment\": {\n            \"sys\": {\n              \"id\": \"master\",\n              \"type\": \"Link\",\n              \"linkType\": \"Environment\"\n            }\n          },\n          \"revision\": 8,\n          \"contentType\": {\n            \"sys\": {\n              \"type\": \"Link\",\n              \"linkType\": \"ContentType\",\n              \"id\": \"cat\"\n            }\n          }\n        },\n        \"fields\": {\n          \"name\": {\n            \"en-US\": \"Happy Cat\",\n            \"tlh\": \"Quch vIghro'\"\n          },\n          \"likes\": {\n            \"en-US\": [\n              \"cheezburger\"\n            ]\n          },\n          \"color\": {\n            \"en-US\": \"gray\"\n          },\n          \"bestFriend\": {\n            \"en-US\": {\n              \"sys\": {\n                \"type\": \"Link\",\n                \"linkType\": \"Entry\",\n                \"id\": \"nyancat\"\n              }\n            }\n          },\n          \"birthday\": {\n            \"en-US\": \"2003-10-28T23:00:00+00:00\"\n          },\n          \"lives\": {\n            \"en-US\": 1\n          },\n          \"image\": {\n            \"en-US\": {\n              \"sys\": {\n                \"type\": \"Link\",\n                \"linkType\": \"Asset\",\n                \"id\": \"happycat\"\n              }\n            }\n          }\n        }\n      }\n    ],\n    \"Asset\": [\n      {\n        \"sys\": {\n          \"space\": {\n            \"sys\": {\n              \"type\": \"Link\",\n              \"linkType\": \"Space\",\n              \"id\": \"cfexampleapi\"\n            }\n          },\n          \"id\": \"happycat\",\n          \"type\": \"Asset\",\n          \"createdAt\": \"2013-09-02T14:56:34.267Z\",\n          \"updatedAt\": \"2013-09-02T15:11:24.361Z\",\n          \"environment\": {\n            \"sys\": {\n              \"id\": \"master\",\n              \"type\": \"Link\",\n              \"linkType\": \"Environment\"\n            }\n          },\n          \"revision\": 2\n        },\n        \"fields\": {\n          \"title\": {\n            \"en-US\": \"Happy Cat\"\n          },\n          \"file\": {\n            \"en-US\": {\n              \"url\": \"\/\/images.ctfassets.net\/cfexampleapi\/3MZPnjZTIskAIIkuuosCss\/382a48dfa2cb16c47aa2c72f7b23bf09\/happycatw.jpg\",\n              \"details\": {\n                \"size\": 59939,\n                \"image\": {\n                  \"width\": 273,\n                  \"height\": 397\n                }\n              },\n              \"fileName\": \"happycatw.jpg\",\n              \"contentType\": \"image\/jpeg\"\n            }\n          }\n        }\n      },\n      {\n        \"sys\": {\n          \"space\": {\n            \"sys\": {\n              \"type\": \"Link\",\n              \"linkType\": \"Space\",\n              \"id\": \"cfexampleapi\"\n            }\n          },\n          \"id\": \"nyancat\",\n          \"type\": \"Asset\",\n          \"createdAt\": \"2013-09-02T14:56:34.240Z\",\n          \"updatedAt\": \"2013-09-02T14:56:34.240Z\",\n          \"environment\": {\n            \"sys\": {\n              \"id\": \"master\",\n              \"type\": \"Link\",\n              \"linkType\": \"Environment\"\n            }\n          },\n          \"revision\": 1\n        },\n        \"fields\": {\n          \"title\": {\n            \"en-US\": \"Nyan Cat\"\n          },\n          \"file\": {\n            \"en-US\": {\n              \"url\": \"\/\/images.ctfassets.net\/cfexampleapi\/4gp6taAwW4CmSgumq2ekUm\/9da0cd1936871b8d72343e895a00d611\/Nyan_cat_250px_frame.png\",\n              \"details\": {\n                \"size\": 12273,\n                \"image\": {\n                  \"width\": 250,\n                  \"height\": 250\n                }\n              },\n              \"fileName\": \"Nyan_cat_250px_frame.png\",\n              \"contentType\": \"image\/png\"\n            }\n          }\n        }\n      }\n    ]\n  }\n}\n"
+    }
+},{
+    "request": {
+        "method": "GET",
+        "url": "https:\/\/cdn.contentful.com\/spaces\/cfexampleapi\/environments\/master\/content_types?sys.id%5Bin%5D=cat",
+        "headers": {
+            "Host": "cdn.contentful.com",
+            "User-Agent": "GuzzleHttp\/6.3.3 curl\/7.54.0 PHP\/7.1.22",
+            "X-Contentful-User-Agent": "sdk contentful.php\/4.0.0-dev; platform PHP\/7.1.22; os macOS;",
+            "Accept": "application\/vnd.contentful.delivery.v1+json",
+            "Accept-Encoding": "gzip",
+            "Authorization": "Bearer b4c0n73n7fu1"
+        }
+    },
+    "response": {
+        "status": {
+            "http_version": "1.1",
+            "code": "200",
+            "message": "OK"
+        },
+        "headers": {
+            "Access-Control-Allow-Headers": "Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature",
+            "Access-Control-Allow-Methods": "GET,HEAD,OPTIONS",
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Expose-Headers": "Etag",
+            "Access-Control-Max-Age": "86400",
+            "Cache-Control": "max-age=0",
+            "Content-Encoding": "gzip",
+            "Content-Type": "application\/vnd.contentful.delivery.v1+json",
+            "Contentful-Api": "cda_cached",
+            "ETag": "W\/\"6f85f13b515f26b382a0c13512194136\"",
+            "Server": "Contentful",
+            "X-Content-Type-Options": "nosniff",
+            "X-Contentful-Region": "us-east-1",
+            "X-Contentful-Request-Id": "4a63ec47fca05b98e71c4e5f8cfbf093",
+            "Content-Length": "614",
+            "Accept-Ranges": "bytes",
+            "Date": "Fri, 19 Oct 2018 13:26:37 GMT",
+            "Via": "1.1 varnish",
+            "Age": "185",
+            "Connection": "keep-alive",
+            "X-Served-By": "cache-hhn1523-HHN",
+            "X-Cache": "HIT",
+            "X-Cache-Hits": "1",
+            "X-Timer": "S1539955597.245827,VS0,VE1",
+            "Vary": "Accept-Encoding"
+        },
+        "body": "{\n  \"sys\": {\n    \"type\": \"Array\"\n  },\n  \"total\": 1,\n  \"skip\": 0,\n  \"limit\": 100,\n  \"items\": [\n    {\n      \"sys\": {\n        \"space\": {\n          \"sys\": {\n            \"type\": \"Link\",\n            \"linkType\": \"Space\",\n            \"id\": \"cfexampleapi\"\n          }\n        },\n        \"id\": \"cat\",\n        \"type\": \"ContentType\",\n        \"createdAt\": \"2013-06-27T22:46:12.852Z\",\n        \"updatedAt\": \"2017-07-06T09:58:52.691Z\",\n        \"environment\": {\n          \"sys\": {\n            \"id\": \"master\",\n            \"type\": \"Link\",\n            \"linkType\": \"Environment\"\n          }\n        },\n        \"revision\": 8\n      },\n      \"displayField\": \"name\",\n      \"name\": \"Cat\",\n      \"description\": \"Meow.\",\n      \"fields\": [\n        {\n          \"id\": \"name\",\n          \"name\": \"Name\",\n          \"type\": \"Text\",\n          \"localized\": true,\n          \"required\": true,\n          \"disabled\": false,\n          \"omitted\": false\n        },\n        {\n          \"id\": \"likes\",\n          \"name\": \"Likes\",\n          \"type\": \"Array\",\n          \"localized\": false,\n          \"required\": false,\n          \"disabled\": false,\n          \"omitted\": false,\n          \"items\": {\n            \"type\": \"Symbol\",\n            \"validations\": []\n          }\n        },\n        {\n          \"id\": \"color\",\n          \"name\": \"Color\",\n          \"type\": \"Symbol\",\n          \"localized\": false,\n          \"required\": false,\n          \"disabled\": false,\n          \"omitted\": false\n        },\n        {\n          \"id\": \"bestFriend\",\n          \"name\": \"Best Friend\",\n          \"type\": \"Link\",\n          \"localized\": false,\n          \"required\": false,\n          \"disabled\": false,\n          \"omitted\": false,\n          \"linkType\": \"Entry\"\n        },\n        {\n          \"id\": \"birthday\",\n          \"name\": \"Birthday\",\n          \"type\": \"Date\",\n          \"localized\": false,\n          \"required\": false,\n          \"disabled\": false,\n          \"omitted\": false\n        },\n        {\n          \"id\": \"lifes\",\n          \"name\": \"Lifes left\",\n          \"type\": \"Integer\",\n          \"localized\": false,\n          \"required\": false,\n          \"disabled\": true,\n          \"omitted\": false\n        },\n        {\n          \"id\": \"lives\",\n          \"name\": \"Lives left\",\n          \"type\": \"Integer\",\n          \"localized\": false,\n          \"required\": false,\n          \"disabled\": false,\n          \"omitted\": false\n        },\n        {\n          \"id\": \"image\",\n          \"name\": \"Image\",\n          \"type\": \"Link\",\n          \"localized\": false,\n          \"required\": false,\n          \"disabled\": false,\n          \"omitted\": false,\n          \"linkType\": \"Asset\"\n        }\n      ]\n    }\n  ]\n}\n"
+    }
+},{
+    "request": {
+        "method": "GET",
+        "url": "https:\/\/cdn.contentful.com\/spaces\/cfexampleapi",
+        "headers": {
+            "Host": "cdn.contentful.com",
+            "User-Agent": "GuzzleHttp\/6.3.3 curl\/7.54.0 PHP\/7.1.22",
+            "X-Contentful-User-Agent": "sdk contentful.php\/4.0.0-dev; platform PHP\/7.1.22; os macOS;",
+            "Accept": "application\/vnd.contentful.delivery.v1+json",
+            "Accept-Encoding": "gzip",
+            "Authorization": "Bearer b4c0n73n7fu1"
+        }
+    },
+    "response": {
+        "status": {
+            "http_version": "1.1",
+            "code": "200",
+            "message": "OK"
+        },
+        "headers": {
+            "Access-Control-Allow-Headers": "Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature",
+            "Access-Control-Allow-Methods": "GET,HEAD,OPTIONS",
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Expose-Headers": "Etag",
+            "Access-Control-Max-Age": "86400",
+            "Cache-Control": "max-age=0",
+            "Content-Type": "application\/vnd.contentful.delivery.v1+json",
+            "Contentful-Api": "cda_cached",
+            "ETag": "\"17f6b9f68596176aed46fa020bf235af\"",
+            "Server": "Contentful",
+            "X-Content-Type-Options": "nosniff",
+            "X-Contentful-Region": "us-east-1",
+            "X-Contentful-Request-Id": "83d244ce356c5996da438b1ba613f7c4",
+            "Content-Length": "344",
+            "Accept-Ranges": "bytes",
+            "Date": "Fri, 19 Oct 2018 13:26:38 GMT",
+            "Via": "1.1 varnish",
+            "Age": "0",
+            "Connection": "keep-alive",
+            "X-Served-By": "cache-hhn1546-HHN",
+            "X-Cache": "HIT",
+            "X-Cache-Hits": "1",
+            "X-Timer": "S1539955598.826302,VS0,VE201",
+            "Vary": "Accept-Encoding"
+        },
+        "body": "{\n  \"sys\": {\n    \"type\": \"Space\",\n    \"id\": \"cfexampleapi\"\n  },\n  \"name\": \"Contentful Example API\",\n  \"locales\": [\n    {\n      \"code\": \"en-US\",\n      \"default\": true,\n      \"name\": \"English\",\n      \"fallbackCode\": null\n    },\n    {\n      \"code\": \"tlh\",\n      \"default\": false,\n      \"name\": \"Klingon\",\n      \"fallbackCode\": \"en-US\"\n    }\n  ]\n}\n"
+    }
+},{
+    "request": {
+        "method": "GET",
+        "url": "https:\/\/cdn.contentful.com\/spaces\/cfexampleapi\/environments\/master\/locales",
+        "headers": {
+            "Host": "cdn.contentful.com",
+            "User-Agent": "GuzzleHttp\/6.3.3 curl\/7.54.0 PHP\/7.1.22",
+            "X-Contentful-User-Agent": "sdk contentful.php\/4.0.0-dev; platform PHP\/7.1.22; os macOS;",
+            "Accept": "application\/vnd.contentful.delivery.v1+json",
+            "Accept-Encoding": "gzip",
+            "Authorization": "Bearer b4c0n73n7fu1"
+        }
+    },
+    "response": {
+        "status": {
+            "http_version": "1.1",
+            "code": "200",
+            "message": "OK"
+        },
+        "headers": {
+            "Access-Control-Allow-Headers": "Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent,X-Contentful-Enable-Alpha-Feature",
+            "Access-Control-Allow-Methods": "GET,HEAD,OPTIONS",
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Expose-Headers": "Etag",
+            "Access-Control-Max-Age": "86400",
+            "Cache-Control": "max-age=0",
+            "Content-Type": "application\/vnd.contentful.delivery.v1+json",
+            "Contentful-Api": "cda_cached",
+            "ETag": "\"028bb030b13282c4390f03bf31ad99f8\"",
+            "Server": "Contentful",
+            "X-Content-Type-Options": "nosniff",
+            "X-Contentful-Region": "us-east-1",
+            "X-Contentful-Request-Id": "cbdbea099ccda35a2390ae5f28f7e6fa",
+            "Content-Length": "546",
+            "Accept-Ranges": "bytes",
+            "Date": "Fri, 19 Oct 2018 13:26:38 GMT",
+            "Via": "1.1 varnish",
+            "Age": "0",
+            "Connection": "keep-alive",
+            "X-Served-By": "cache-hhn1525-HHN",
+            "X-Cache": "MISS",
+            "X-Cache-Hits": "0",
+            "X-Timer": "S1539955599.739457,VS0,VE117",
+            "Vary": "Accept-Encoding"
+        },
+        "body": "{\n  \"sys\": {\n    \"type\": \"Array\"\n  },\n  \"total\": 2,\n  \"skip\": 0,\n  \"limit\": 1000,\n  \"items\": [\n    {\n      \"code\": \"en-US\",\n      \"name\": \"English\",\n      \"default\": true,\n      \"fallbackCode\": null,\n      \"sys\": {\n        \"id\": \"2oQPjMCL9bQkylziydLh57\",\n        \"type\": \"Locale\",\n        \"version\": 1\n      }\n    },\n    {\n      \"code\": \"tlh\",\n      \"name\": \"Klingon\",\n      \"default\": false,\n      \"fallbackCode\": \"en-US\",\n      \"sys\": {\n        \"id\": \"3zpZmkZrHTIekHmXgflXaV\",\n        \"type\": \"Locale\",\n        \"version\": 0\n      }\n    }\n  ]\n}\n"
+    }
+}]

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -43,7 +43,7 @@ VCR::configure()
     ->setMode('once')
     ->setStorage('json')
     ->enableLibraryHooks(['stream_wrapper', 'curl'])
-    ->setCassettePath('tests/Recordings')
+    ->setCassettePath(__DIR__ . '/Recordings')
     ->addRequestMatcher('custom_headers', function (Request $first, Request $second) {
         $first = clean_headers_array($first);
         $second = clean_headers_array($second);


### PR DESCRIPTION
I wanted to upgrade from `2.4.2` to `3.4.0` but then I realized that we now have one call for every asset in the fetched entries. After some debugging I found out that when using the `?locale=*` parameter, the cache key always uses the `__ALL__` suffix, but when requesting the asset the current locale is used (in this case `en-US`) which does not exist in the resource pool.

I then decided to adjust the ResourcePool so it also checks for the `__ALL__` key whenever the locale-specific one was not found. I'm not sure if this is the correct/perfect way, but every other solutions seemed more of a hack than this one.