### PR TITLE
Return all resources when some already cached

### DIFF
--- a/src/LinkResolver.php
+++ b/src/LinkResolver.php
@@ -144,7 +144,7 @@ class LinkResolver implements LinkResolverInterface
         }
 
         foreach ($this->createIdChunks($resourceIds) as $chunk) {
-            $resources += $this->fetchCollectionFromApi($chunk, $type, $locale);
+            $resources = \array_merge($resources, $this->fetchCollectionFromApi($chunk, $type, $locale));
         }
 
         return $resources;


### PR DESCRIPTION
The link resolver isn't fetching all resources when some are already present in the cache pool.

The cause of this is is in the LinkResolver fetchResourcesForGivenIds function:

- The resources fetched from the pool are put into a numerically indexed array.
- The resources fetched from the api (via fetchCollectionFromApi) are also a numerically indexed array.
- The arrays are combined using the + operator.

> The + operator returns the right-hand array appended to the left-hand array; for keys that exist in both arrays, the elements from the left-hand array will be used, and the matching elements from the right-hand array will be ignored.

[More Info](https://stackoverflow.com/questions/5394157/whats-the-difference-between-array-merge-and-array-array)

Combining the arrays using array_merge appears to produce the desired behaviour.
