### PR TITLE
adding ClientOptions::withoutMessageLogging

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ $options = \Contentful\Delivery\ClientOptions::create()
     ->withLogger(Psr\Log\LoggerInterface $logger)
     ->withCache(Psr\Cache\CacheItemPoolInterface $cache, bool $autoWarmup = false, bool $cacheContent = false)
     ->withHttpClient(GuzzleHttp\Client $client)
+    ->withoutMessageLogging()
 ;
 
 $client = new \Contentful\Delivery\Client(
@@ -158,6 +159,7 @@ $client = new \Contentful\Delivery\Client(
 | `withCache()` | `bool $autoWarmup = false` | When using a cache pool, set this to true to automatically fill the cache during regular use |
 | `withCache()` | `bool $cacheContent = false` | When using a cache pool with `$autoWarmup` set to true, se this to true to fill the cache with entries and assets during runtime. This may speed up execution when calling `$client->getEntry($entryId)` and `$client->getAsset($assetId)`, but *not* when calling the `getEntries()` and `getAssets()` methods, as the client can't reliably know which entries or assets will be returned by the API, and for this reason the cache can't intercept the call. |
 | `withHttpClient()` | `GuzzleHttp\Client $client` | A Guzzle client instance, which can be configured with custom middleware |
+| `withoutMessageLogging()` | - | Do not store API requests and responses (which can use a lot of memory). If messages are not stored, they will not be retrievable from `Client::getMessages()` for debugging and inspection purposes |
 
 ### Reference documentation
 

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.2",
-        "contentful/core": "^3.0",
+        "contentful/core": "^3.1",
         "contentful/rich-text": "^3.1",
         "psr/cache": "^1.0",
         "symfony/console": "~2.7|~3.0|~4.0|^5.0",
@@ -16,7 +16,7 @@
         "phpunit/phpunit": "^8.5",
         "php-vcr/phpunit-testlistener-vcr": "3.0.0|^3.2",
         "cache/array-adapter": "^1.0",
-        "php-vcr/php-vcr": "dev-issues/289 as 1.4.5"
+        "php-vcr/php-vcr": "^1.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.2",
-        "contentful/core": "^3.1",
+        "contentful/core": "^3.0",
         "contentful/rich-text": "^3.1",
         "psr/cache": "^1.0",
         "symfony/console": "~2.7|~3.0|~4.0|^5.0",

--- a/src/Client.php
+++ b/src/Client.php
@@ -148,7 +148,7 @@ class Client extends BaseClient implements ClientInterface, SynchronizationClien
         $this->richTextParser = new Parser($this->linkResolver);
         $this->builder = new ResourceBuilder($this, $this->resourcePool, $this->richTextParser);
 
-        parent::__construct($token, $options->getHost(), $options->getLogger(), $options->getHttpClient());
+        parent::__construct($token, $options->getHost(), $options->getLogger(), $options->getHttpClient(), $options->usesMessageLogging());
     }
 
     /**

--- a/src/ClientOptions.php
+++ b/src/ClientOptions.php
@@ -60,6 +60,11 @@ class ClientOptions
     private $usesLowMemoryResourcePool = false;
 
     /**
+     * @var bool
+     */
+    private $messageLogging = true;
+
+    /**
      * ClientOptions constructor.
      */
     public function __construct()
@@ -207,5 +212,17 @@ class ClientOptions
     public function usesLowMemoryResourcePool(): bool
     {
         return $this->usesLowMemoryResourcePool;
+    }
+
+    public function withoutMessageLogging(): self
+    {
+        $this->messageLogging = false;
+
+        return $this;
+    }
+
+    public function usesMessageLogging(): bool
+    {
+        return $this->messageLogging;
     }
 }

--- a/tests/Unit/ClientOptionsTest.php
+++ b/tests/Unit/ClientOptionsTest.php
@@ -32,6 +32,7 @@ class ClientOptionsTest extends TestCase
         $this->assertFalse($options->hasCacheContent());
         $this->assertNull($options->getDefaultLocale());
         $this->assertFalse($options->usesLowMemoryResourcePool());
+        $this->assertTrue($options->usesMessageLogging());
     }
 
     public function testGetSet()
@@ -69,5 +70,8 @@ class ClientOptionsTest extends TestCase
 
         $options->withNormalResourcePool();
         $this->assertFalse($options->usesLowMemoryResourcePool());
+
+        $options->withoutMessageLogging();
+        $this->assertFalse($options->usesMessageLogging());
     }
 }


### PR DESCRIPTION
As a follow-up patch to https://github.com/contentful/contentful.php/issues/294 this patch exposes the ability to disable the logging
of messages via ClientOptions. The default behaviour remains to continue to log messages.
Bumped the minimum required version of contentful/core to ^3.1 in anticipation that the next release will indeed be v3.1.
In passing, update the php-vcr version requirement to the latest version, as the branch it was trying to use no longer exists.