### PR TITLE
Replace cache/void-adapter with symfony/cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,16 +7,16 @@
         "php": "^7.2|^8.0",
         "contentful/core": "^3.0",
         "contentful/rich-text": "^3.1",
-        "psr/cache": "^1.0|^3.0",
+        "psr/cache": "^1.0|^2.0|^3.0",
+        "psr/log": "^1.1|^2.0|^3.0",
+        "symfony/cache": "^5.0|^6.0",
         "symfony/console": "~2.7|~3.0|~4.0|^5.0|^6.0",
-        "symfony/filesystem": "~2.7|~3.0|~4.0|~5.0|^6.0",
-        "cache/void-adapter": "^1.0"
+        "symfony/filesystem": "~2.7|~3.0|~4.0|~5.0|^6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5",
-        "php-vcr/phpunit-testlistener-vcr": "3.0.0|^3.2",
-        "cache/array-adapter": "^1.0",
         "php-vcr/php-vcr": "^1.5",
+        "php-vcr/phpunit-testlistener-vcr": "3.0.0|^3.2",
+        "phpunit/phpunit": "^8.5",
         "roave/backward-compatibility-check": "^3.0|^5.0|^6.1"
     },
     "autoload": {
@@ -45,15 +45,13 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "4.2.0-dev"
+            "dev-master": "6.3.x-dev"
         }
-    },
-    "suggest": {
-        "symfony/cache": "A PSR-6 compatible cache component"
     },
     "config": {
         "allow-plugins": {
             "composer/package-versions-deprecated": true
-        }
+        },
+        "sort-packages": true
     }
 }

--- a/src/ClientOptions.php
+++ b/src/ClientOptions.php
@@ -11,11 +11,11 @@ declare(strict_types=1);
 
 namespace Contentful\Delivery;
 
-use Cache\Adapter\Void\VoidCachePool;
-use Contentful\Core\Log\NullLogger;
 use GuzzleHttp\Client as HttpClient;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Component\Cache\Adapter\NullAdapter;
 
 class ClientOptions
 {
@@ -69,7 +69,7 @@ class ClientOptions
      */
     public function __construct()
     {
-        $this->cacheItemPool = new VoidCachePool();
+        $this->cacheItemPool = new NullAdapter();
         $this->logger = new NullLogger();
         $this->httpClient = new HttpClient();
     }

--- a/tests/Implementation/CacheItemPoolFactory.php
+++ b/tests/Implementation/CacheItemPoolFactory.php
@@ -11,14 +11,14 @@ declare(strict_types=1);
 
 namespace Contentful\Tests\Delivery\Implementation;
 
-use Cache\Adapter\PHPArray\ArrayCachePool;
 use Contentful\Delivery\Cache\CacheItemPoolFactoryInterface;
 use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 class CacheItemPoolFactory implements CacheItemPoolFactoryInterface
 {
     /**
-     * @var ArrayCachePool[]
+     * @var CacheItemPoolInterface[]
      */
     public static $pools = [];
 
@@ -37,7 +37,7 @@ class CacheItemPoolFactory implements CacheItemPoolFactoryInterface
     {
         $key = $api.'.'.$spaceId.'.'.$environmentId;
         if (!isset(self::$pools[$key])) {
-            self::$pools[$key] = new ArrayCachePool();
+            self::$pools[$key] = new ArrayAdapter();
         }
 
         return self::$pools[$key];

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,12 +11,12 @@ declare(strict_types=1);
 
 namespace Contentful\Tests\Delivery;
 
-use Cache\Adapter\PHPArray\ArrayCachePool;
 use Contentful\Delivery\Client;
 use Contentful\Delivery\Client\JsonDecoderClientInterface;
 use Contentful\Delivery\ClientOptions;
 use Contentful\Tests\TestCase as BaseTestCase;
 use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 class TestCase extends BaseTestCase
 {
@@ -29,7 +29,7 @@ class TestCase extends BaseTestCase
 
     public static function setUpBeforeClass(): void
     {
-        self::$cache = new ArrayCachePool();
+        self::$cache = new ArrayAdapter();
     }
 
     protected function getClient(string $key): Client

--- a/tests/Unit/ClientOptionsTest.php
+++ b/tests/Unit/ClientOptionsTest.php
@@ -11,12 +11,12 @@ declare(strict_types=1);
 
 namespace Contentful\Tests\Delivery\Unit;
 
-use Cache\Adapter\PHPArray\ArrayCachePool;
-use Contentful\Core\Log\NullLogger;
 use Contentful\Delivery\ClientOptions;
 use Contentful\Tests\Delivery\TestCase;
 use GuzzleHttp\Client as HttpClient;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 class ClientOptionsTest extends TestCase
 {
@@ -51,7 +51,7 @@ class ClientOptionsTest extends TestCase
         $options->withDefaultLocale('it-IT');
         $this->assertSame('it-IT', $options->getDefaultLocale());
 
-        $cachePool = new ArrayCachePool();
+        $cachePool = new ArrayAdapter();
         $options->withCache($cachePool, true, true);
         $this->assertSame($cachePool, $options->getCacheItemPool());
         $this->assertTrue($options->hasCacheAutoWarmup());

--- a/tests/Unit/ResourcePool/ExtendedTest.php
+++ b/tests/Unit/ResourcePool/ExtendedTest.php
@@ -11,17 +11,17 @@ declare(strict_types=1);
 
 namespace Contentful\Tests\Delivery\Unit\ResourcePool;
 
-use Cache\Adapter\PHPArray\ArrayCachePool;
 use Contentful\Delivery\ResourcePool\Extended;
 use Contentful\Tests\Delivery\Implementation\JsonDecoderClient;
 use Contentful\Tests\Delivery\Implementation\MockEntry;
 use Contentful\Tests\Delivery\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 class ExtendedTest extends TestCase
 {
     public function testGetSetData()
     {
-        $resourcePool = new Extended(new JsonDecoderClient(), new ArrayCachePool(), true);
+        $resourcePool = new Extended(new JsonDecoderClient(), new ArrayAdapter(), true);
 
         $this->assertFalse($resourcePool->has('Entry', 'entryId', ['locale' => 'en-US']));
         $entry = MockEntry::withSys('entryId', [], 'en-US');
@@ -36,14 +36,14 @@ class ExtendedTest extends TestCase
         $this->expectException(\OutOfBoundsException::class);
         $this->expectExceptionMessage('Resource pool could not find a resource with type "Entry", ID "invalidId", and locale "en-US".');
 
-        $instanceRepository = new Extended(new JsonDecoderClient(), new ArrayCachePool());
+        $instanceRepository = new Extended(new JsonDecoderClient(), new ArrayAdapter());
 
         $instanceRepository->get('Entry', 'invalidId', ['locale' => 'en-US']);
     }
 
     public function testGenerateKey()
     {
-        $instanceRepository = new Extended(new JsonDecoderClient(), new ArrayCachePool());
+        $instanceRepository = new Extended(new JsonDecoderClient(), new ArrayAdapter());
 
         $key = $instanceRepository->generateKey(
             'Entry',

--- a/tests/Unit/ResourcePoolTest.php
+++ b/tests/Unit/ResourcePoolTest.php
@@ -11,17 +11,17 @@ declare(strict_types=1);
 
 namespace Contentful\Tests\Delivery\Unit;
 
-use Cache\Adapter\PHPArray\ArrayCachePool;
 use Contentful\Delivery\ResourcePool;
 use Contentful\Tests\Delivery\Implementation\JsonDecoderClient;
 use Contentful\Tests\Delivery\Implementation\MockEntry;
 use Contentful\Tests\Delivery\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 class ResourcePoolTest extends TestCase
 {
     public function testGetSetData()
     {
-        $resourcePool = new ResourcePool(new JsonDecoderClient(), new ArrayCachePool(), true);
+        $resourcePool = new ResourcePool(new JsonDecoderClient(), new ArrayAdapter(), true);
 
         $this->assertFalse($resourcePool->has('Entry', 'entryId', ['locale' => 'en-US']));
         $entry = MockEntry::withSys('entryId', [], 'en-US');
@@ -36,14 +36,14 @@ class ResourcePoolTest extends TestCase
         $this->expectException(\OutOfBoundsException::class);
         $this->expectExceptionMessage('Resource pool could not find a resource with type "Entry", ID "invalidId", and locale "en-US".');
 
-        $instanceRepository = new ResourcePool(new JsonDecoderClient(), new ArrayCachePool());
+        $instanceRepository = new ResourcePool(new JsonDecoderClient(), new ArrayAdapter());
 
         $instanceRepository->get('Entry', 'invalidId', ['locale' => 'en-US']);
     }
 
     public function testGenerateKey()
     {
-        $instanceRepository = new ResourcePool(new JsonDecoderClient(), new ArrayCachePool());
+        $instanceRepository = new ResourcePool(new JsonDecoderClient(), new ArrayAdapter());
 
         $key = $instanceRepository->generateKey(
             'Entry',


### PR DESCRIPTION
Replace cache/void-adapter with symfony/cache because the void-adapter package is not updated any more. From the php cache main repository:

> Back in 2016, this was the first library supporting PSR-6. We created Symfony bundles and made many great libraries in the PHP-cache organization. This was a few years ago and the library is not activly maintained. Starting a new project one should consider using the more performant and activly supported [Symfony Cache](https://symfony.com/doc/current/components/cache.html).
> https://github.com/php-cache/cache#php-cache

See also https://github.com/contentful/contentful-core.php/pull/53