### PR TITLE
Increase `contentful/core` version to 3.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "license": "MIT",
     "require": {
-        "php": "^7.2|^8",
+        "php": "^7.2|^8.0",
         "contentful/core": "^3.1",
         "contentful/rich-text": "^3.1",
         "psr/cache": "^1.0|^2.0",


### PR DESCRIPTION

`contentful/core` is now updated to rely on `guzzlehttp/psr7@^2.0`  by bumping minimum the version it enables compatability for pre-existing projects using `guzzlehttp/psr7@^2.0`