### PR TITLE
Deprecation message for JsonSerializable

### DIFF
--- a/src/SystemProperties/BaseSystemProperties.php
+++ b/src/SystemProperties/BaseSystemProperties.php
@@ -50,7 +50,7 @@ abstract class BaseSystemProperties implements SystemPropertiesInterface
     /**
      * {@inheritdoc}
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'id' => $this->id,


### PR DESCRIPTION
> Method "JsonSerializable::jsonSerialize()" might add "mixed" as a native return type declaration in the future. 

Adding explicit `array` return type to suppress this message.

There is already [an open PR](https://github.com/contentful/contentful.php/pull/317) that change the return type to `mixed` but this type is only available in php 8 and the repo is php > 7.2.