### PR TITLE
chore: moved to symfony 7 / 8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,9 @@
         "contentful/rich-text": "^4.0",
         "psr/cache": "^2.0|^3.0",
         "psr/log": "^1.0|^2.0|^3.0",
-        "symfony/cache": "^5.0|^6.0|^7.0",
-        "symfony/console": "~2.7|~3.0|~4.0|^5.0|^6.0|^7.0",
-        "symfony/filesystem": "~2.7|~3.0|~4.0|~5.0|^6.0|^7.0"
+        "symfony/cache": "^7.0|^8.0",
+        "symfony/console": "^7.0|^8.0",
+        "symfony/filesystem": "^7.0|^8.0"
     },
     "require-dev": {
         "php-vcr/php-vcr": "^1.6.3",


### PR DESCRIPTION
This pull request updates the Symfony dependencies in the `composer.json` file to require only the latest major versions, which improves compatibility and ensures access to new features and security updates.

Dependency version updates:

* Updated `symfony/cache`, `symfony/console`, and `symfony/filesystem` to require `^7.0|^8.0`, removing support for older versions and simplifying the version constraints.