### PR TITLE
Fix: Extended ResourcePool never updates stale cached entries

### DIFF
--- a/src/ResourcePool/Extended.php
+++ b/src/ResourcePool/Extended.php
@@ -106,9 +106,7 @@ class Extended extends Standard
 
     public function save(ResourceInterface $resource): bool
     {
-        if (!parent::save($resource)) {
-            return false;
-        }
+        parent::save($resource);
 
         $key = $this->generateKey(
             $resource->getType(),
@@ -118,10 +116,8 @@ class Extended extends Standard
 
         if ($this->autoWarmup && \in_array($resource->getType(), $this->warmupTypes, true)) {
             $cacheItem = $this->cacheItemPool->getItem($key);
-            if (!$cacheItem->isHit()) {
-                $cacheItem->set(guzzle_json_encode($resource));
-                $this->cacheItemPool->save($cacheItem);
-            }
+            $cacheItem->set(guzzle_json_encode($resource));
+            $this->cacheItemPool->save($cacheItem);
         }
 
         return true;


### PR DESCRIPTION
## Summary

The `save()` method in `Extended` ResourcePool has two issues that prevent cached entries from ever being updated once initially stored in the PSR-6 cache.

### Bug 1: `parent::save()` gates the cache write

`Standard::save()` returns `false` when the resource already exists in the in-memory pool — which is the case whenever `warmUp()` has loaded it from cache earlier in the same request. `Extended::save()` treats this `false` as "nothing to do" and returns before reaching the PSR-6 cache write:

```php
if (!parent::save($resource)) {
    return false; // ← Never reaches Redis/cache write
}
```

### Bug 2: `isHit()` prevents overwriting

Even if bug 1 didn't exist, the `isHit()` guard explicitly prevents overwriting existing cache entries:

```php
if (!$cacheItem->isHit()) { // ← Skips write for existing entries
    $cacheItem->set(guzzle_json_encode($resource));
    $this->cacheItemPool->save($cacheItem);
}
```

### Combined effect

Once an Entry or Asset is cached in the PSR-6 pool, the SDK can **never update it** even when a fresh version is fetched directly from the Contentful API. The only way to get fresh data is to flush the entire cache store.

### Reproduction

1. Configure the client with `cacheContent: true` and `autoWarmup: true`
2. Fetch an entry via `getEntries()` it gets cached in the PSR-6 pool
3. Update the entry in Contentful
4. Fetch the same entry again via `getEntries()` the API returns fresh data
5. On the **same request**: the in-memory pool has the fresh version (mapper mutates in-place)
6. On the **next request**: `warmUp()` loads the **stale** version from the PSR-6 cache, because `save()` never wrote the fresh version

### Fix

- Ignore `parent::save()`'s return value. The in-memory pool is still updated by the parent call, but we always proceed to the cache write
- Remove the `isHit()` guard so stale cache entries are overwritten with fresh data 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>The PR fixes a bug in the Extended ResourcePool where cached entries were never updated once stored in the PSR-6 cache. The save() method had two issues: it gated cache writes based on parent::save() return value and prevented overwriting existing cache entries with an isHit() check. This combined effect meant stale data persisted indefinitely. The fix ignores the parent return value and removes the isHit() guard to ensure fresh API data always updates the cache.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Removes the condition that checks parent::save() return value, ensuring the method always proceeds to cache operations in Extended.php</li>

<li>Eliminates the isHit() guard before setting and saving cache items, allowing overwrites of existing entries in Extended.php</li>

</ul>
</details>

</div>